### PR TITLE
Feat/772 access requests

### DIFF
--- a/frontend/app/interactions/actions.test.ts
+++ b/frontend/app/interactions/actions.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/interactions/api", () => ({
+  submitAccessRequest: vi.fn(),
+}))
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}))
+
+import { submitAccessRequest } from "@/lib/interactions/api"
+import { submitAccessRequestAction } from "./actions"
+
+const VALID_BODY = {
+  reportName: "Sales Dashboard",
+  reportUrl: "https://example.com/reports/1",
+  directorName: "Jane Smith",
+}
+
+describe("submitAccessRequestAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("delegates to submitAccessRequest and returns data on success", async () => {
+    vi.mocked(submitAccessRequest).mockResolvedValueOnce({ ok: true, data: {} })
+
+    const result = await submitAccessRequestAction(VALID_BODY)
+
+    expect(submitAccessRequest).toHaveBeenCalledWith(VALID_BODY)
+    expect(result).toEqual({ data: {} })
+  })
+
+  it("returns the API error message when submitAccessRequest fails", async () => {
+    vi.mocked(submitAccessRequest).mockResolvedValueOnce({
+      ok: false,
+      message: "Report name is required.",
+      code: "bad_request",
+    })
+
+    const result = await submitAccessRequestAction(VALID_BODY)
+
+    expect(submitAccessRequest).toHaveBeenCalledWith(VALID_BODY)
+    expect(result).toEqual({ error: "Report name is required." })
+  })
+})

--- a/frontend/components/interactions/entity-card-footer.test.tsx
+++ b/frontend/components/interactions/entity-card-footer.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+const { requestAccessDialogMock } = vi.hoisted(() => ({
+  requestAccessDialogMock: vi.fn(
+    ({
+      reportName,
+      reportUrl,
+      variant,
+    }: {
+      reportName: string
+      reportUrl: string
+      variant?: string
+    }) => (
+      <div data-testid="request-access-dialog">
+        {reportName} — {reportUrl} — {variant ?? "default"}
+      </div>
+    ),
+  ),
+}))
+
+vi.mock("@/components/interactions/request-access-dialog", () => ({
+  RequestAccessDialog: requestAccessDialogMock,
+}))
+
+vi.mock("@/app/interactions/actions", () => ({
+  toggleStarAction: vi.fn(async () => ({ data: { isStarred: false, count: 0 } })),
+}))
+
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { EntityCardFooter } from "./entity-card-footer"
+
+function renderFooter(props: React.ComponentProps<typeof EntityCardFooter>) {
+  return render(
+    <TooltipProvider>
+      <EntityCardFooter {...props} />
+    </TooltipProvider>,
+  )
+}
+
+describe("EntityCardFooter request access entry point", () => {
+  it("renders RequestAccessDialog on report cards in collection listings", () => {
+    renderFooter({
+      entityType: "report",
+      id: 7,
+      title: "Monthly KPI Pack",
+      href: "/reports?id=7",
+      canRequestAccess: true,
+      features: { requestAccessEnabled: true },
+      profilePanel: <div>Profile</div>,
+    })
+
+    expect(screen.getByTestId("request-access-dialog")).toBeInTheDocument()
+    const dialogProps = requestAccessDialogMock.mock.calls[0]?.[0]
+    expect(dialogProps).toEqual(
+      expect.objectContaining({
+        reportName: "Monthly KPI Pack",
+        reportUrl: "/reports?id=7",
+        variant: "footer",
+      }),
+    )
+  })
+
+  it("does not render RequestAccessDialog when canRequestAccess is false", () => {
+    renderFooter({
+      entityType: "report",
+      id: 7,
+      title: "Monthly KPI Pack",
+      href: "/reports?id=7",
+      canRequestAccess: false,
+      features: { requestAccessEnabled: true },
+      profilePanel: <div>Profile</div>,
+    })
+
+    expect(screen.queryByTestId("request-access-dialog")).not.toBeInTheDocument()
+  })
+
+  it("does not render RequestAccessDialog for collection cards", () => {
+    renderFooter({
+      entityType: "collection",
+      id: 3,
+      title: "Finance Collection",
+      href: "/collections?id=3",
+      profilePanel: <div>Profile</div>,
+    })
+
+    expect(screen.queryByTestId("request-access-dialog")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/components/interactions/entity-engagement-rail-actions.test.tsx
+++ b/frontend/components/interactions/entity-engagement-rail-actions.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+const { requestAccessDialogMock } = vi.hoisted(() => ({
+  requestAccessDialogMock: vi.fn(
+    ({ reportName, reportUrl }: { reportName: string; reportUrl: string }) => (
+      <div data-testid="request-access-dialog">
+        {reportName} — {reportUrl}
+      </div>
+    ),
+  ),
+}))
+
+vi.mock("@/components/interactions/request-access-dialog", () => ({
+  RequestAccessDialog: requestAccessDialogMock,
+}))
+
+vi.mock("@/app/interactions/actions", () => ({
+  toggleStarAction: vi.fn(async () => ({ data: { isStarred: false, count: 0 } })),
+}))
+
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { EntityEngagementRailActions } from "./entity-engagement-rail-actions"
+
+function renderRail(props: React.ComponentProps<typeof EntityEngagementRailActions>) {
+  return render(
+    <TooltipProvider>
+      <EntityEngagementRailActions {...props} />
+    </TooltipProvider>,
+  )
+}
+
+const BASE_PROPS = {
+  entityType: "report" as const,
+  entityId: 42,
+  entityName: "Executive Dashboard",
+  entityUrl: "/reports?id=42",
+  profileLabel: "report profile",
+  profilePanel: <div>Profile</div>,
+  isStarred: false,
+  starCount: 0,
+}
+
+describe("EntityEngagementRailActions request access entry point", () => {
+  it("renders RequestAccessDialog on the report action rail when enabled", () => {
+    renderRail({
+      ...BASE_PROPS,
+      showRequestAccess: true,
+      features: { requestAccessEnabled: true },
+    })
+
+    expect(screen.getByTestId("request-access-dialog")).toBeInTheDocument()
+    const dialogProps = requestAccessDialogMock.mock.calls[0]?.[0]
+    expect(dialogProps).toEqual(
+      expect.objectContaining({
+        reportName: "Executive Dashboard",
+        reportUrl: "/reports?id=42",
+      }),
+    )
+  })
+
+  it("does not render RequestAccessDialog when showRequestAccess is false", () => {
+    renderRail({
+      ...BASE_PROPS,
+      features: { requestAccessEnabled: true },
+    })
+
+    expect(screen.queryByTestId("request-access-dialog")).not.toBeInTheDocument()
+  })
+
+  it("does not render RequestAccessDialog when the feature flag is disabled", () => {
+    renderRail({
+      ...BASE_PROPS,
+      showRequestAccess: true,
+      features: { requestAccessEnabled: false },
+    })
+
+    expect(screen.queryByTestId("request-access-dialog")).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Review Ask Status

Here’s how each point maps:

| **Review ask** | **Status** |
|---|---|
| Dialog tests (success, missing director, validation, service failure) | ✅ Already covered by `request-access-dialog.test.tsx` (on `dev`, included in the rebased branch) |
| Verify `/api/interactions/access-request` fetch | ✅ Covered by `api.test.ts` — asserts `POST` to the correct endpoint with JSON body + auth header |
| API/action-level assertion (not just mocked dialog action) | ✅ Added `actions.test.ts` — `submitAccessRequestAction` delegates to `submitAccessRequest` and maps success/error |
| Entry-point check (report + collection) | ✅ Added entry-point tests for **report action rail** (`entity-engagement-rail-actions.test.tsx`) and **report cards in collection listings** (`entity-card-footer.test.tsx`) |
| Merge conflict resolved | ✅ PR is now **`MERGEABLE`** with **`mergeStateStatus: CLEAN`** |

### Test Coverage Stack

```text
Dialog UI
  → request-access-dialog.test.tsx
    (mocks action — fine for UI)

Action wiring
  → actions.test.ts
    (NEW)

API fetch
  → api.test.ts
    (POST /api/interactions/access-request)

Entry points
  → entity-engagement-rail-actions.test.tsx
    (NEW — report rail)

  → entity-card-footer.test.tsx
    (NEW — collection report cards)