### PR TITLE
feat: add SAML authentication flow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
 WORKDIR /app
 
-RUN apk add --no-cache icu-libs
+RUN apk add --no-cache ca-certificates icu-libs
 
 COPY --from=build ["/app/web/out", "./"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     ports:
       - '${WEB_PORT:-5000}:${WEB_PORT:-5000}'
     healthcheck:
-      test: ['CMD-SHELL', 'wget -qO- http://127.0.0.1:${WEB_PORT:-5000}/ || exit 1']
+      test: ['CMD-SHELL', 'wget -qO- http://127.0.0.1:${WEB_PORT:-5000}/healthz >/dev/null || exit 1']
       interval: 15s
       timeout: 5s
       retries: 10

--- a/web.Tests/FunctionTests/ProgramConfiguration.Tests.cs
+++ b/web.Tests/FunctionTests/ProgramConfiguration.Tests.cs
@@ -1,0 +1,36 @@
+using Atlas_Web;
+using ITfoxtec.Identity.Saml2.Schemas;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+using Xunit;
+
+namespace web.Tests.FunctionTests;
+
+public class ProgramConfigurationTests
+{
+    [Fact]
+    public void ConfigureJwtAuthentication_UsesSamlWhenSamlConfigurationExists()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Demo"] = "false",
+            ["Jwt:Key"] = "test-jwt-secret-key-for-saml-config-test-32-chars",
+            ["Jwt:Issuer"] = "test-issuer",
+            ["Jwt:Audience"] = "test-audience",
+            ["Saml2:Issuer"] = "atlas-library",
+        });
+
+        ProgramConfiguration.ConfigureJwtAuthentication(builder);
+
+        using var provider = builder.Services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<AuthenticationOptions>>().Value;
+
+        Assert.Equal(Saml2Constants.AuthenticationScheme, options.DefaultAuthenticateScheme);
+        Assert.Equal(Saml2Constants.AuthenticationScheme, options.DefaultChallengeScheme);
+    }
+}

--- a/web/Controllers/Asc.cs
+++ b/web/Controllers/Asc.cs
@@ -25,16 +25,6 @@ namespace Atlas_Web.Controllers
         {
             var binding = new Saml2PostBinding();
             var saml2AuthnResponse = new Saml2AuthnResponse(config);
-            var relayStateQuery = binding.GetRelayStateQuery();
-            var returnUrl = relayStateQuery.ContainsKey(relayStateReturnUrl)
-                ? relayStateQuery[relayStateReturnUrl]
-                : Url.Content("~/");
-
-            // if a login existed.. use it
-            if (User.Identity.IsAuthenticated)
-            {
-                return Redirect(returnUrl);
-            }
 
             binding.ReadSamlResponse(Request.ToGenericHttpRequest(), saml2AuthnResponse);
             if (saml2AuthnResponse.Status != Saml2StatusCodes.Success)
@@ -45,6 +35,16 @@ namespace Atlas_Web.Controllers
             }
 
             binding.Unbind(Request.ToGenericHttpRequest(), saml2AuthnResponse);
+            var relayStateQuery = binding.GetRelayStateQuery();
+            var returnUrl = relayStateQuery.ContainsKey(relayStateReturnUrl)
+                ? relayStateQuery[relayStateReturnUrl]
+                : Url.Content("~/");
+
+            // if a login existed.. use it
+            if (User.Identity.IsAuthenticated)
+            {
+                return Redirect(returnUrl);
+            }
 
             await saml2AuthnResponse.CreateSession(
                 HttpContext,

--- a/web/Program.cs
+++ b/web/Program.cs
@@ -351,9 +351,14 @@ app.UseStaticFiles(
 app.UseETagger();
 app.UseRouting();
 app.UseCors("NextJs");
+if (app.Configuration.GetSection("Saml2").Exists())
+{
+    app.UseSaml2();
+}
 app.UseAuthentication();
 app.UseAuthorization();
 
+app.MapGet("/healthz", () => Results.Ok(new { status = "ok" })).AllowAnonymous();
 app.MapRazorPages();
 app.MapControllers();
 

--- a/web/ProgramConfiguration.cs
+++ b/web/ProgramConfiguration.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Atlas_Web.Configuration;
 using Atlas_Web.Authentication;
 using Atlas_Web.Services;
+using ITfoxtec.Identity.Saml2.Schemas;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authentication.Negotiate;
 using Microsoft.IdentityModel.Tokens;
@@ -86,6 +87,10 @@ public static class ProgramConfiguration
         {
             ConfigureDemoAuthentication(builder, jwtIssuer, jwtAudience, signingKey);
         }
+        else if (builder.Configuration.GetSection("Saml2").Exists())
+        {
+            ConfigureSamlAuthentication(builder, jwtIssuer, jwtAudience, signingKey);
+        }
         else
         {
             ConfigureNegotiateAuthentication(builder, jwtIssuer, jwtAudience, signingKey);
@@ -143,6 +148,34 @@ public static class ProgramConfiguration
                     IssuerSigningKey = signingKey,
                 };
             });
+    }
+
+    private static void ConfigureSamlAuthentication(
+        WebApplicationBuilder builder,
+        string jwtIssuer,
+        string jwtAudience,
+        SymmetricSecurityKey signingKey)
+    {
+        builder.Services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = Saml2Constants.AuthenticationScheme;
+                options.DefaultChallengeScheme = Saml2Constants.AuthenticationScheme;
+                options.DefaultSignInScheme = Saml2Constants.AuthenticationScheme;
+            }
+        )
+        .AddJwtBearer("Bearer", options =>
+        {
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                ValidIssuer = jwtIssuer,
+                ValidAudience = jwtAudience,
+                IssuerSigningKey = signingKey,
+            };
+        });
     }
 
     private static void ConfigureTestSsoAuthentication(


### PR DESCRIPTION
## Summary
- activate the existing C# SAML configuration when SAML is configured
- preserve the SAML RelayState callback through JWT handoff to Next.js
- add an anonymous health endpoint for the container health check

## Verification
- dotnet test web.Tests/web.Tests.csproj --no-restore --filter 'FullyQualifiedName~ProgramConfigurationTests'