### PR TITLE
feat(settings): integrate frontend Settings with /api/settings (#802)

### DIFF
--- a/frontend/app/settings/actions.ts
+++ b/frontend/app/settings/actions.ts
@@ -1,0 +1,171 @@
+﻿"use server"
+
+import { revalidatePath } from "next/cache"
+import {
+  addGroupRole,
+  addSiteMessage,
+  addUserRole,
+  createRole,
+  createTag,
+  deleteRole,
+  deleteSiteMessage,
+  deleteTag,
+  removeGroupRole,
+  removeUserRole,
+  updateEtl,
+  updateRolePermission,
+  updateSearchReportTypeText,
+  updateSearchVisibility,
+  updateTheme,
+} from "@/lib/settings/api"
+import type { ParameterRequest, RoleRequest, SiteMessageRequest } from "@/lib/settings/types"
+import type { TagType } from "@/lib/settings/api"
+
+function revalidateSettings() {
+  revalidatePath("/settings")
+}
+
+// ---------------------------------------------------------------------------
+// Site Messages
+// ---------------------------------------------------------------------------
+
+export async function addSiteMessageAction(body: SiteMessageRequest) {
+  const result = await addSiteMessage(body)
+  if (!result.ok) return { error: result.message }
+  revalidateSettings()
+  return { data: result.data }
+}
+
+export async function deleteSiteMessageAction(id: number) {
+  const result = await deleteSiteMessage(id)
+  if (!result.ok) return { error: result.message }
+  revalidateSettings()
+  return { data: {} }
+}
+
+// ---------------------------------------------------------------------------
+// ETL
+// ---------------------------------------------------------------------------
+
+export async function updateEtlAction(value: string | null) {
+  const result = await updateEtl(value)
+  if (!result.ok) return { error: result.message }
+  revalidateSettings()
+  return { data: {} }
+}
+
+// ---------------------------------------------------------------------------
+// Theme
+// ---------------------------------------------------------------------------
+
+export async function updateThemeAction(value: string | null) {
+  const result = await updateTheme(value)
+  if (!result.ok) return { error: result.message }
+  revalidateSettings()
+  return { data: {} }
+}
+
+// ---------------------------------------------------------------------------
+// Search
+// ---------------------------------------------------------------------------
+
+export async function updateSearchVisibilityAction(
+  type: string,
+  visible: boolean,
+  reportTypeId?: number,
+) {
+  const result = await updateSearchVisibility(type, visible, reportTypeId)
+  if (!result.ok) return { error: result.message }
+  revalidatePath("/settings")
+  return { data: {} }
+}
+
+export async function updateSearchReportTypeTextAction(id: number, text: string | null) {
+  const result = await updateSearchReportTypeText(id, text)
+  if (!result.ok) return { error: result.message }
+  revalidatePath("/settings")
+  return { data: {} }
+}
+
+// ---------------------------------------------------------------------------
+// Tags
+// ---------------------------------------------------------------------------
+
+export async function createTagAction(type: TagType, body: ParameterRequest) {
+  const result = await createTag(type, body)
+  if (!result.ok) return { error: result.message }
+  revalidatePath("/settings")
+  return { data: result.data }
+}
+
+export async function deleteTagAction(type: TagType, id: number) {
+  const result = await deleteTag(type, id)
+  if (!result.ok) return { error: result.message }
+  revalidatePath("/settings")
+  return { data: {} }
+}
+
+// ---------------------------------------------------------------------------
+// Roles
+// ---------------------------------------------------------------------------
+
+export async function createRoleAction(body: RoleRequest) {
+  const result = await createRole(body)
+  if (!result.ok) return { error: result.message }
+  revalidatePath("/settings")
+  return { data: result.data }
+}
+
+export async function deleteRoleAction(id: number) {
+  const result = await deleteRole(id)
+  if (!result.ok) return { error: result.message }
+  revalidatePath("/settings")
+  return { data: {} }
+}
+
+export async function updateRolePermissionAction(
+  roleId: number,
+  permissionId: number,
+  enabled: boolean,
+) {
+  const result = await updateRolePermission(roleId, permissionId, enabled)
+  if (!result.ok) return { error: result.message }
+  revalidatePath("/settings")
+  return { data: {} }
+}
+
+// ---------------------------------------------------------------------------
+// User Roles
+// ---------------------------------------------------------------------------
+
+export async function addUserRoleAction(userId: number, roleId: number) {
+  const result = await addUserRole(userId, roleId)
+  if (!result.ok) return { error: result.message }
+  revalidatePath("/settings")
+  return { data: {} }
+}
+
+export async function removeUserRoleAction(userId: number, roleId: number) {
+  const result = await removeUserRole(userId, roleId)
+  if (!result.ok) return { error: result.message }
+  revalidatePath("/settings")
+  return { data: {} }
+}
+
+// ---------------------------------------------------------------------------
+// Group Roles
+// ---------------------------------------------------------------------------
+
+export async function addGroupRoleAction(groupId: number, roleId: number) {
+  const result = await addGroupRole(groupId, roleId)
+  if (!result.ok) return { error: result.message }
+  revalidatePath("/settings")
+  return { data: {} }
+}
+
+export async function removeGroupRoleAction(groupId: number, roleId: number) {
+  const result = await removeGroupRole(groupId, roleId)
+  if (!result.ok) return { error: result.message }
+  revalidatePath("/settings")
+  return { data: {} }
+}

--- a/frontend/app/settings/actions.ts
+++ b/frontend/app/settings/actions.ts
@@ -1,6 +1,9 @@
 ﻿"use server"
 
 import { revalidatePath } from "next/cache"
+import { searchReportUsers } from "@/lib/reports/api"
+import { searchLibrary } from "@/lib/search/api"
+import type { TagType } from "@/lib/settings/api"
 import {
   addGroupRole,
   addSiteMessage,
@@ -19,7 +22,6 @@ import {
   updateTheme,
 } from "@/lib/settings/api"
 import type { ParameterRequest, RoleRequest, SiteMessageRequest } from "@/lib/settings/types"
-import type { TagType } from "@/lib/settings/api"
 
 function revalidateSettings() {
   revalidatePath("/settings")
@@ -168,4 +170,28 @@ export async function removeGroupRoleAction(groupId: number, roleId: number) {
   if (!result.ok) return { error: result.message }
   revalidatePath("/settings")
   return { data: {} }
+}
+
+// ---------------------------------------------------------------------------
+// Lookup helpers for user/group assignment
+// ---------------------------------------------------------------------------
+
+export async function searchSettingsUsersAction(query: string) {
+  return searchReportUsers(query)
+}
+
+export async function searchSettingsGroupsAction(query: string) {
+  const trimmed = query.trim()
+  if (!trimmed) return []
+
+  const result = await searchLibrary({ q: trimmed, type: "groups" })
+  if (!result.data?.results) return []
+
+  return result.data.results
+    .filter((item) => item.type === "groups")
+    .map((item) => ({
+      id: item.atlasId,
+      name: item.name,
+      description: item.description,
+    }))
 }

--- a/frontend/app/settings/layout.tsx
+++ b/frontend/app/settings/layout.tsx
@@ -1,0 +1,85 @@
+﻿import { redirect } from "next/navigation"
+import type { Metadata } from "next"
+import type { ReactNode } from "react"
+import { LibraryShell } from "@/components/layout/library-shell"
+import { SettingsTabController } from "@/components/settings/settings-tab-controller"
+import { getCurrentUser, getToken } from "@/lib/auth"
+
+export const metadata: Metadata = {
+  title: "Settings",
+  description: "Admin settings for Atlas Library.",
+}
+
+export default async function SettingsLayout({ children }: { children: ReactNode }) {
+  const token = await getToken()
+  if (!token) redirect("/auth/login")
+
+  const user = await getCurrentUser()
+  const canEditRoles = user?.roles?.includes("Administrator") ?? false
+
+  const navItems = [
+    { href: "#roles", label: "Role Configuration", icon: "fa-lock", show: canEditRoles },
+    { href: "#user-roles", label: "User Roles", icon: "fa-user-lock", show: canEditRoles },
+    { href: "#user-groups", label: "Group Roles", icon: "fa-users", show: canEditRoles },
+    { href: "#meta-fields", label: "Meta Fields", icon: "fa-list-ul", show: true },
+    { href: "#site-message", label: "Site Message", icon: "fa-comment", show: true },
+    { href: "#search", label: "Search", icon: "fa-search", show: true },
+    { href: "#theme", label: "Theme", icon: "fa-palette", show: true },
+    { href: "#etl", label: "ETL", icon: "fa-database", show: true },
+  ].filter((item) => item.show)
+
+  const defaultTab = canEditRoles ? "roles" : "meta-fields"
+
+  return (
+    <LibraryShell
+      displayName={user?.fullname?.trim() || user?.username?.trim() || "Guest"}
+      isSignedIn={Boolean(user)}
+      isAdministrator={user?.roles?.includes("Administrator") ?? false}
+      adminEnabled={user?.adminEnabled ?? false}
+    >
+      <div className="max-w-[1280px] mx-auto py-8 px-4">
+        {/* Breadcrumb */}
+        <div className="text-[14px] font-medium mb-4 flex items-center">
+          <span className="text-[#363636]">Settings</span>
+          <span className="text-[#dbdbdb] mx-2">/</span>
+          <span className="text-[#485fc7]">Home</span>
+        </div>
+        
+        <h1 className="text-[40px] font-bold font-serif text-[#363636] mb-6 tracking-tight leading-tight">Settings</h1>
+
+        <div className="flex flex-col md:flex-row gap-[1.5rem] items-start">
+          {/* Sidebar Navigation */}
+          <div className="w-full md:w-[280px] shrink-0">
+            <nav className="bg-white rounded-[6px] shadow-[0_0.5em_1em_-0.125em_rgba(10,10,10,0.1),0_0_0_1px_rgba(10,10,10,0.02)] overflow-hidden flex flex-col">
+              {navItems.map((item, i) => (
+                <a
+                  key={item.href}
+                  href={item.href}
+                  className={`panel-tab flex items-center px-4 py-[0.875rem] text-[15px] font-medium transition-colors border-b border-[#ededed] last:border-b-0 ${
+                    i === 0 
+                      ? "text-[#485fc7] bg-[#f5f5f5]" 
+                      : "text-[#363636] hover:bg-[#f5f5f5]"
+                  }`}
+                >
+                  <span className={`w-7 text-center mr-3 text-lg ${i === 0 ? "text-[#485fc7]" : "text-[#4a4a4a]"}`}>
+                    <i className={`fas ${item.icon}`} aria-hidden="true" />
+                  </span>
+                  {item.label}
+                </a>
+              ))}
+            </nav>
+          </div>
+
+          {/* Main Content Area */}
+          <div className="flex-1 min-w-0 w-full">
+            <div className="bg-white rounded-[6px] shadow-[0_0.5em_1em_-0.125em_rgba(10,10,10,0.1),0_0_0_1px_rgba(10,10,10,0.02)] p-8">
+              <SettingsTabController defaultTab={defaultTab}>
+                {children}
+              </SettingsTabController>
+            </div>
+          </div>
+        </div>
+      </div>
+    </LibraryShell>
+  )
+}

--- a/frontend/app/settings/layout.tsx
+++ b/frontend/app/settings/layout.tsx
@@ -1,9 +1,9 @@
-﻿import { redirect } from "next/navigation"
-import type { Metadata } from "next"
+﻿import type { Metadata } from "next"
+import { redirect } from "next/navigation"
 import type { ReactNode } from "react"
 import { LibraryShell } from "@/components/layout/library-shell"
 import { SettingsTabController } from "@/components/settings/settings-tab-controller"
-import { getCurrentUser, getToken } from "@/lib/auth"
+import { getCurrentUser, getToken, hasPermission } from "@/lib/auth"
 
 export const metadata: Metadata = {
   title: "Settings",
@@ -15,12 +15,14 @@ export default async function SettingsLayout({ children }: { children: ReactNode
   if (!token) redirect("/auth/login")
 
   const user = await getCurrentUser()
-  const canEditRoles = user?.roles?.includes("Administrator") ?? false
+  const canEditRoles = !!user && hasPermission(user, "Edit Role Permissions")
+  const canEditUsers = !!user && hasPermission(user, "Edit User Permissions")
+  const canEditGroups = !!user && hasPermission(user, "Edit Group Permissions")
 
   const navItems = [
     { href: "#roles", label: "Role Configuration", icon: "fa-lock", show: canEditRoles },
-    { href: "#user-roles", label: "User Roles", icon: "fa-user-lock", show: canEditRoles },
-    { href: "#user-groups", label: "Group Roles", icon: "fa-users", show: canEditRoles },
+    { href: "#user-roles", label: "User Roles", icon: "fa-user-lock", show: canEditUsers },
+    { href: "#user-groups", label: "Group Roles", icon: "fa-users", show: canEditGroups },
     { href: "#meta-fields", label: "Meta Fields", icon: "fa-list-ul", show: true },
     { href: "#site-message", label: "Site Message", icon: "fa-comment", show: true },
     { href: "#search", label: "Search", icon: "fa-search", show: true },
@@ -28,7 +30,7 @@ export default async function SettingsLayout({ children }: { children: ReactNode
     { href: "#etl", label: "ETL", icon: "fa-database", show: true },
   ].filter((item) => item.show)
 
-  const defaultTab = canEditRoles ? "roles" : "meta-fields"
+  const defaultTab = canEditRoles ? "roles" : canEditUsers ? "user-roles" : "meta-fields"
 
   return (
     <LibraryShell
@@ -38,30 +40,26 @@ export default async function SettingsLayout({ children }: { children: ReactNode
       adminEnabled={user?.adminEnabled ?? false}
     >
       <div className="max-w-[1280px] mx-auto py-8 px-4">
-        {/* Breadcrumb */}
         <div className="text-[14px] font-medium mb-4 flex items-center">
           <span className="text-[#363636]">Settings</span>
           <span className="text-[#dbdbdb] mx-2">/</span>
           <span className="text-[#485fc7]">Home</span>
         </div>
-        
-        <h1 className="text-[40px] font-bold font-serif text-[#363636] mb-6 tracking-tight leading-tight">Settings</h1>
+
+        <h1 className="text-[40px] font-bold font-serif text-[#363636] mb-6 tracking-tight leading-tight">
+          Settings
+        </h1>
 
         <div className="flex flex-col md:flex-row gap-[1.5rem] items-start">
-          {/* Sidebar Navigation */}
           <div className="w-full md:w-[280px] shrink-0">
             <nav className="bg-white rounded-[6px] shadow-[0_0.5em_1em_-0.125em_rgba(10,10,10,0.1),0_0_0_1px_rgba(10,10,10,0.02)] overflow-hidden flex flex-col">
-              {navItems.map((item, i) => (
+              {navItems.map((item) => (
                 <a
                   key={item.href}
                   href={item.href}
-                  className={`panel-tab flex items-center px-4 py-[0.875rem] text-[15px] font-medium transition-colors border-b border-[#ededed] last:border-b-0 ${
-                    i === 0 
-                      ? "text-[#485fc7] bg-[#f5f5f5]" 
-                      : "text-[#363636] hover:bg-[#f5f5f5]"
-                  }`}
+                  className="panel-tab flex items-center px-4 py-[0.875rem] text-[15px] font-medium transition-colors border-b border-[#ededed] last:border-b-0 text-[#363636] hover:bg-[#f5f5f5]"
                 >
-                  <span className={`w-7 text-center mr-3 text-lg ${i === 0 ? "text-[#485fc7]" : "text-[#4a4a4a]"}`}>
+                  <span className="w-7 text-center mr-3 text-lg text-[#4a4a4a]">
                     <i className={`fas ${item.icon}`} aria-hidden="true" />
                   </span>
                   {item.label}
@@ -70,12 +68,9 @@ export default async function SettingsLayout({ children }: { children: ReactNode
             </nav>
           </div>
 
-          {/* Main Content Area */}
           <div className="flex-1 min-w-0 w-full">
             <div className="bg-white rounded-[6px] shadow-[0_0.5em_1em_-0.125em_rgba(10,10,10,0.1),0_0_0_1px_rgba(10,10,10,0.02)] p-8">
-              <SettingsTabController defaultTab={defaultTab}>
-                {children}
-              </SettingsTabController>
+              <SettingsTabController defaultTab={defaultTab}>{children}</SettingsTabController>
             </div>
           </div>
         </div>

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -70,14 +70,21 @@ export default async function SettingsPage() {
           <RolesPanel initialRoles={rolesResult.data} permissions={permissionsResult.data} />
         ) : (
           <p className="text-red-500">
-            {!rolesResult.ok ? rolesResult.message : !permissionsResult.ok ? permissionsResult.message : ""}
+            {!rolesResult.ok
+              ? rolesResult.message
+              : !permissionsResult.ok
+                ? permissionsResult.message
+                : ""}
           </p>
         )}
       </div>
 
       <div id="user-roles" className="panel-tab-data hidden">
         {rolesResult.ok && userRolesResult.ok ? (
-          <UserRolesPanel initialAssignments={userRolesResult.data} availableRoles={rolesResult.data} />
+          <UserRolesPanel
+            initialAssignments={userRolesResult.data}
+            availableRoles={rolesResult.data}
+          />
         ) : (
           <p className="text-red-500">{!userRolesResult.ok ? userRolesResult.message : ""}</p>
         )}
@@ -85,7 +92,10 @@ export default async function SettingsPage() {
 
       <div id="user-groups" className="panel-tab-data hidden">
         {rolesResult.ok && groupRolesResult.ok ? (
-          <GroupRolesPanel initialAssignments={groupRolesResult.data} availableRoles={rolesResult.data} />
+          <GroupRolesPanel
+            initialAssignments={groupRolesResult.data}
+            availableRoles={rolesResult.data}
+          />
         ) : (
           <p className="text-red-500">{!groupRolesResult.ok ? groupRolesResult.message : ""}</p>
         )}

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,0 +1,151 @@
+﻿import type { Metadata } from "next"
+import { EtlThemePanel } from "@/components/settings/etl-theme-panel"
+import { GroupRolesPanel } from "@/components/settings/group-roles-panel"
+import { RolesPanel } from "@/components/settings/roles-panel"
+import { SearchSettingsPanel } from "@/components/settings/search-settings-panel"
+import { SiteMessagesPanel } from "@/components/settings/site-messages-panel"
+import { TagsSettingsPanel } from "@/components/settings/tags-settings-panel"
+import { UserRolesPanel } from "@/components/settings/user-roles-panel"
+import {
+  getDefaultEtl,
+  getEtl,
+  getGroupRoles,
+  getPermissions,
+  getRoles,
+  getSearch,
+  getSiteMessages,
+  getTags,
+  getTheme,
+  getUserRoles,
+} from "@/lib/settings/api"
+
+export const metadata: Metadata = { title: "Settings" }
+
+export default async function SettingsPage() {
+  const [
+    messagesResult,
+    etlResult,
+    themeResult,
+    defaultEtlResult,
+    searchResult,
+    rolesResult,
+    permissionsResult,
+    userRolesResult,
+    groupRolesResult,
+    orgValues,
+    runFreqs,
+    frags,
+    fragTags,
+    maintSchedules,
+    maintStatuses,
+    finImpacts,
+    stratImps,
+    tags,
+  ] = await Promise.all([
+    getSiteMessages(),
+    getEtl(),
+    getTheme(),
+    getDefaultEtl(),
+    getSearch(),
+    getRoles(),
+    getPermissions(),
+    getUserRoles(),
+    getGroupRoles(),
+    getTags("organizational-values"),
+    getTags("estimated-run-frequencies"),
+    getTags("fragilities"),
+    getTags("fragility-tags"),
+    getTags("maintenance-schedules"),
+    getTags("maintenance-log-statuses"),
+    getTags("financial-impacts"),
+    getTags("strategic-importances"),
+    getTags("tags"),
+  ])
+
+  return (
+    <>
+      {/* Tab panels — the SettingsTabController client component handles visibility via 'hidden' */}
+      <div id="roles" className="panel-tab-data hidden">
+        {rolesResult.ok && permissionsResult.ok ? (
+          <RolesPanel initialRoles={rolesResult.data} permissions={permissionsResult.data} />
+        ) : (
+          <p className="text-red-500">
+            {!rolesResult.ok ? rolesResult.message : !permissionsResult.ok ? permissionsResult.message : ""}
+          </p>
+        )}
+      </div>
+
+      <div id="user-roles" className="panel-tab-data hidden">
+        {rolesResult.ok && userRolesResult.ok ? (
+          <UserRolesPanel initialAssignments={userRolesResult.data} availableRoles={rolesResult.data} />
+        ) : (
+          <p className="text-red-500">{!userRolesResult.ok ? userRolesResult.message : ""}</p>
+        )}
+      </div>
+
+      <div id="user-groups" className="panel-tab-data hidden">
+        {rolesResult.ok && groupRolesResult.ok ? (
+          <GroupRolesPanel initialAssignments={groupRolesResult.data} availableRoles={rolesResult.data} />
+        ) : (
+          <p className="text-red-500">{!groupRolesResult.ok ? groupRolesResult.message : ""}</p>
+        )}
+      </div>
+
+      <div id="meta-fields" className="panel-tab-data hidden">
+        <TagsSettingsPanel
+          organizationalValues={orgValues.ok ? orgValues.data : []}
+          estimatedRunFrequencies={runFreqs.ok ? runFreqs.data : []}
+          fragilities={frags.ok ? frags.data : []}
+          fragilityTags={fragTags.ok ? fragTags.data : []}
+          maintenanceSchedules={maintSchedules.ok ? maintSchedules.data : []}
+          maintenanceLogStatuses={maintStatuses.ok ? maintStatuses.data : []}
+          financialImpacts={finImpacts.ok ? finImpacts.data : []}
+          strategicImportances={stratImps.ok ? stratImps.data : []}
+          tags={tags.ok ? tags.data : []}
+        />
+      </div>
+
+      <div id="site-message" className="panel-tab-data hidden">
+        {messagesResult.ok ? (
+          <SiteMessagesPanel initialMessages={messagesResult.data} />
+        ) : (
+          <p className="text-red-500">{messagesResult.message}</p>
+        )}
+      </div>
+
+      <div id="search" className="panel-tab-data hidden">
+        {searchResult.ok ? (
+          <SearchSettingsPanel initialData={searchResult.data} />
+        ) : (
+          <p className="text-red-500">{searchResult.message}</p>
+        )}
+      </div>
+
+      <div id="theme" className="panel-tab-data hidden">
+        {themeResult.ok ? (
+          <EtlThemePanel
+            initialEtl={null}
+            initialTheme={themeResult.data.value ?? null}
+            defaultEtl={null}
+            themeOnly
+          />
+        ) : (
+          <p className="text-red-500">{themeResult.message}</p>
+        )}
+      </div>
+
+      <div id="etl" className="panel-tab-data hidden">
+        {etlResult.ok ? (
+          <EtlThemePanel
+            initialEtl={etlResult.data.value ?? null}
+            initialTheme={null}
+            defaultEtl={defaultEtlResult.ok ? defaultEtlResult.data : null}
+            etlOnly
+          />
+        ) : (
+          <p className="text-red-500">{etlResult.message}</p>
+        )}
+      </div>
+    </>
+  )
+}

--- a/frontend/components/settings/etl-theme-panel.tsx
+++ b/frontend/components/settings/etl-theme-panel.tsx
@@ -1,0 +1,159 @@
+﻿"use client"
+
+import { useTransition, useState } from "react"
+import { RefreshCw } from "lucide-react"
+import { updateEtlAction, updateThemeAction } from "@/app/settings/actions"
+
+interface EtlThemePanelProps {
+  initialEtl: string | null
+  initialTheme: string | null
+  defaultEtl: string | null
+  themeOnly?: boolean
+  etlOnly?: boolean
+}
+
+export function EtlThemePanel({ initialEtl, initialTheme, defaultEtl, themeOnly, etlOnly }: EtlThemePanelProps) {
+  const [etl, setEtl] = useState(initialEtl ?? "")
+  const [theme, setTheme] = useState(initialTheme ?? "")
+  const [etlError, setEtlError] = useState<string | null>(null)
+  const [themeError, setThemeError] = useState<string | null>(null)
+  const [etlSuccess, setEtlSuccess] = useState(false)
+  const [themeSuccess, setThemeSuccess] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  function handleSaveEtl() {
+    setEtlError(null)
+    setEtlSuccess(false)
+    startTransition(async () => {
+      const res = await updateEtlAction(etl || null)
+      if (res.error) {
+        setEtlError(res.error)
+      } else {
+        setEtlSuccess(true)
+      }
+    })
+  }
+
+  function handleSaveTheme() {
+    setThemeError(null)
+    setThemeSuccess(false)
+    startTransition(async () => {
+      const res = await updateThemeAction(theme || null)
+      if (res.error) {
+        setThemeError(res.error)
+      } else {
+        setThemeSuccess(true)
+      }
+    })
+  }
+
+  function handleRestoreDefault() {
+    if (defaultEtl !== null) {
+      setEtl(defaultEtl)
+      setEtlSuccess(false)
+      setEtlError(null)
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* ETL */}
+      {!themeOnly && (
+        <div className="space-y-4">
+          <div>
+            <h2 className="text-2xl font-bold font-serif text-slate-800">Report Tag ETL</h2>
+            <p className="text-slate-500 mt-1 text-sm">
+              SQL script executed to tag reports. Changes take effect on the next ETL run.
+            </p>
+          </div>
+          
+          {etlError && (
+            <div className="bg-red-50 text-red-600 border border-red-200 p-3 rounded-md text-sm">
+              {etlError}
+            </div>
+          )}
+          {etlSuccess && (
+            <div className="bg-green-50 text-green-700 border border-green-200 p-3 rounded-md text-sm">
+              ETL script saved.
+            </div>
+          )}
+          
+          <div className="space-y-2">
+            <label htmlFor="etl-value" className="block text-sm font-semibold text-slate-700">SQL Script</label>
+            <textarea
+              id="etl-value"
+              className="w-full min-h-[300px] font-mono text-sm rounded-md border border-slate-300 bg-white p-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={etl}
+              onChange={(e) => { setEtl(e.target.value); setEtlSuccess(false) }}
+              disabled={isPending}
+              placeholder="-- your ETL SQL here"
+            />
+          </div>
+          
+          <div className="flex gap-3">
+            <button 
+              onClick={handleSaveEtl} 
+              disabled={isPending}
+              className="px-4 py-2 bg-blue-500 text-white rounded-md text-sm font-medium hover:bg-blue-600 transition-colors disabled:opacity-50"
+            >
+              Save ETL
+            </button>
+            {defaultEtl !== null && (
+              <button
+                onClick={handleRestoreDefault}
+                disabled={isPending}
+                className="flex items-center gap-2 px-4 py-2 bg-white text-slate-700 border border-slate-300 rounded-md text-sm font-medium hover:bg-slate-50 transition-colors disabled:opacity-50"
+              >
+                <RefreshCw size={16} />
+                Restore Default
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Theme */}
+      {!etlOnly && (
+        <div className="space-y-4">
+          <div>
+            <h2 className="text-2xl font-bold font-serif text-slate-800">Global CSS Theme</h2>
+            <p className="text-slate-500 mt-1 text-sm">
+              Custom CSS injected into every page. Use with care — malformed CSS can break the UI.
+            </p>
+          </div>
+          
+          {themeError && (
+            <div className="bg-red-50 text-red-600 border border-red-200 p-3 rounded-md text-sm">
+              {themeError}
+            </div>
+          )}
+          {themeSuccess && (
+            <div className="bg-green-50 text-green-700 border border-green-200 p-3 rounded-md text-sm">
+              Theme saved.
+            </div>
+          )}
+          
+          <div className="space-y-2">
+            <label htmlFor="theme-value" className="block text-sm font-semibold text-slate-700">CSS</label>
+            <textarea
+              id="theme-value"
+              className="w-full min-h-[300px] font-mono text-sm rounded-md border border-slate-300 bg-white p-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={theme}
+              onChange={(e) => { setTheme(e.target.value); setThemeSuccess(false) }}
+              disabled={isPending}
+              placeholder="/* custom CSS */"
+            />
+          </div>
+          
+          <button 
+            onClick={handleSaveTheme} 
+            disabled={isPending}
+            className="px-4 py-2 bg-blue-500 text-white rounded-md text-sm font-medium hover:bg-blue-600 transition-colors disabled:opacity-50"
+          >
+            Save Theme
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/settings/etl-theme-panel.tsx
+++ b/frontend/components/settings/etl-theme-panel.tsx
@@ -1,7 +1,7 @@
 ﻿"use client"
 
-import { useTransition, useState } from "react"
 import { RefreshCw } from "lucide-react"
+import { useState, useTransition } from "react"
 import { updateEtlAction, updateThemeAction } from "@/app/settings/actions"
 
 interface EtlThemePanelProps {
@@ -12,7 +12,13 @@ interface EtlThemePanelProps {
   etlOnly?: boolean
 }
 
-export function EtlThemePanel({ initialEtl, initialTheme, defaultEtl, themeOnly, etlOnly }: EtlThemePanelProps) {
+export function EtlThemePanel({
+  initialEtl,
+  initialTheme,
+  defaultEtl,
+  themeOnly,
+  etlOnly,
+}: EtlThemePanelProps) {
   const [etl, setEtl] = useState(initialEtl ?? "")
   const [theme, setTheme] = useState(initialTheme ?? "")
   const [etlError, setEtlError] = useState<string | null>(null)
@@ -66,7 +72,7 @@ export function EtlThemePanel({ initialEtl, initialTheme, defaultEtl, themeOnly,
               SQL script executed to tag reports. Changes take effect on the next ETL run.
             </p>
           </div>
-          
+
           {etlError && (
             <div className="bg-red-50 text-red-600 border border-red-200 p-3 rounded-md text-sm">
               {etlError}
@@ -77,22 +83,28 @@ export function EtlThemePanel({ initialEtl, initialTheme, defaultEtl, themeOnly,
               ETL script saved.
             </div>
           )}
-          
+
           <div className="space-y-2">
-            <label htmlFor="etl-value" className="block text-sm font-semibold text-slate-700">SQL Script</label>
+            <label htmlFor="etl-value" className="block text-sm font-semibold text-slate-700">
+              SQL Script
+            </label>
             <textarea
               id="etl-value"
               className="w-full min-h-[300px] font-mono text-sm rounded-md border border-slate-300 bg-white p-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
               value={etl}
-              onChange={(e) => { setEtl(e.target.value); setEtlSuccess(false) }}
+              onChange={(e) => {
+                setEtl(e.target.value)
+                setEtlSuccess(false)
+              }}
               disabled={isPending}
               placeholder="-- your ETL SQL here"
             />
           </div>
-          
+
           <div className="flex gap-3">
-            <button 
-              onClick={handleSaveEtl} 
+            <button
+              type="button"
+              onClick={handleSaveEtl}
               disabled={isPending}
               className="px-4 py-2 bg-blue-500 text-white rounded-md text-sm font-medium hover:bg-blue-600 transition-colors disabled:opacity-50"
             >
@@ -100,6 +112,7 @@ export function EtlThemePanel({ initialEtl, initialTheme, defaultEtl, themeOnly,
             </button>
             {defaultEtl !== null && (
               <button
+                type="button"
                 onClick={handleRestoreDefault}
                 disabled={isPending}
                 className="flex items-center gap-2 px-4 py-2 bg-white text-slate-700 border border-slate-300 rounded-md text-sm font-medium hover:bg-slate-50 transition-colors disabled:opacity-50"
@@ -121,7 +134,7 @@ export function EtlThemePanel({ initialEtl, initialTheme, defaultEtl, themeOnly,
               Custom CSS injected into every page. Use with care — malformed CSS can break the UI.
             </p>
           </div>
-          
+
           {themeError && (
             <div className="bg-red-50 text-red-600 border border-red-200 p-3 rounded-md text-sm">
               {themeError}
@@ -132,21 +145,27 @@ export function EtlThemePanel({ initialEtl, initialTheme, defaultEtl, themeOnly,
               Theme saved.
             </div>
           )}
-          
+
           <div className="space-y-2">
-            <label htmlFor="theme-value" className="block text-sm font-semibold text-slate-700">CSS</label>
+            <label htmlFor="theme-value" className="block text-sm font-semibold text-slate-700">
+              CSS
+            </label>
             <textarea
               id="theme-value"
               className="w-full min-h-[300px] font-mono text-sm rounded-md border border-slate-300 bg-white p-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
               value={theme}
-              onChange={(e) => { setTheme(e.target.value); setThemeSuccess(false) }}
+              onChange={(e) => {
+                setTheme(e.target.value)
+                setThemeSuccess(false)
+              }}
               disabled={isPending}
               placeholder="/* custom CSS */"
             />
           </div>
-          
-          <button 
-            onClick={handleSaveTheme} 
+
+          <button
+            type="button"
+            onClick={handleSaveTheme}
             disabled={isPending}
             className="px-4 py-2 bg-blue-500 text-white rounded-md text-sm font-medium hover:bg-blue-600 transition-colors disabled:opacity-50"
           >

--- a/frontend/components/settings/group-roles-panel.tsx
+++ b/frontend/components/settings/group-roles-panel.tsx
@@ -1,0 +1,182 @@
+﻿"use client"
+
+import { useState, useTransition } from "react"
+import { Trash2 } from "lucide-react"
+import { addGroupRoleAction, removeGroupRoleAction } from "@/app/settings/actions"
+import type { GroupRoleAssignmentDto, RoleDto } from "@/lib/settings/types"
+import Link from "next/link"
+
+interface Props {
+  initialAssignments: GroupRoleAssignmentDto[]
+  availableRoles: RoleDto[]
+}
+
+export function GroupRolesPanel({ initialAssignments, availableRoles }: Props) {
+  const [assignments, setAssignments] = useState<GroupRoleAssignmentDto[]>(initialAssignments)
+  const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null)
+  const [groupSearch, setGroupSearch] = useState("")
+  const [selectedRoleId, setSelectedRoleId] = useState<number | "">("")
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault()
+    if (!selectedGroupId || !selectedRoleId) {
+      setError("Group and role are required.")
+      return
+    }
+    setError(null)
+    startTransition(async () => {
+      const res = await addGroupRoleAction(selectedGroupId, Number(selectedRoleId))
+      if (res && "error" in res) {
+        setError(res.error as string)
+      } else {
+        const role = availableRoles.find((r) => r.id === Number(selectedRoleId))
+        if (!role) return
+        setAssignments((prev) => {
+          const existing = prev.find((a) => a.groupId === selectedGroupId)
+          if (existing) {
+            return prev.map((a) =>
+              a.groupId === selectedGroupId
+                ? { ...a, roles: [...a.roles, { id: role.id, name: role.name }] }
+                : a,
+            )
+          }
+          return [...prev, { groupId: selectedGroupId, name: groupSearch, roles: [{ id: role.id, name: role.name }] }]
+        })
+        setGroupSearch("")
+        setSelectedGroupId(null)
+        setSelectedRoleId("")
+      }
+    })
+  }
+
+  function handleRemove(groupId: number, roleId: number) {
+    startTransition(async () => {
+      setError(null)
+      const res = await removeGroupRoleAction(groupId, roleId)
+      if (res && "error" in res) {
+        setError(res.error as string)
+      } else {
+        setAssignments((prev) =>
+          prev
+            .map((a) =>
+              a.groupId === groupId ? { ...a, roles: a.roles.filter((r) => r.id !== roleId) } : a,
+            )
+            .filter((a) => a.roles.length > 0),
+        )
+      }
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-2xl font-bold font-serif text-slate-800">Group Roles</h2>
+      
+      <div className="space-y-4">
+        <h3 className="text-xl font-semibold text-slate-800">Add Privileged Group</h3>
+
+        {error && (
+          <div className="bg-red-50 text-red-600 border border-red-200 p-4 rounded-md">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleAdd} className="space-y-4 max-w-xl">
+          <div className="space-y-2">
+            <label className="block text-sm font-semibold text-slate-700">Group</label>
+            <input
+              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="type to search..."
+              value={groupSearch}
+              onChange={(e) => setGroupSearch(e.target.value)}
+            />
+          </div>
+          
+          <div className="space-y-2">
+            <label className="block text-sm font-semibold text-slate-700">Group ID</label>
+            <input
+              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              type="number"
+              placeholder="Group ID"
+              value={selectedGroupId ?? ""}
+              onChange={(e) => setSelectedGroupId(e.target.value ? Number(e.target.value) : null)}
+            />
+          </div>
+          
+          <div className="space-y-2">
+            <label className="block text-sm font-semibold text-slate-700">Role</label>
+            <select
+              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={selectedRoleId}
+              onChange={(e) => setSelectedRoleId(e.target.value ? Number(e.target.value) : "")}
+            >
+              <option value="">Select a role...</option>
+              {availableRoles
+                .filter((r) => r.name !== "Administrator" && r.name !== "User")
+                .map((r) => (
+                  <option key={r.id} value={r.id}>
+                    {r.name}
+                  </option>
+                ))}
+            </select>
+          </div>
+          
+          <button 
+            className="px-4 py-2 bg-blue-500 text-white rounded-md text-sm font-medium hover:bg-blue-600 transition-colors disabled:opacity-50"
+            type="submit" 
+            disabled={isPending}
+          >
+            Save
+          </button>
+        </form>
+      </div>
+
+      <div className="space-y-4">
+        <h3 className="text-xl font-semibold text-slate-800">Privileged Groups</h3>
+        <div className="overflow-x-auto border border-slate-200 rounded-md">
+          <table className="w-full text-sm text-left">
+            <thead className="bg-slate-50 border-b border-slate-200 text-slate-700">
+              <tr>
+                <th className="px-4 py-3 font-semibold">Group</th>
+                <th className="px-4 py-3 font-semibold">Role</th>
+                <th className="px-4 py-3 font-semibold">Remove Role</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 bg-white">
+              {assignments.length === 0 && (
+                <tr>
+                  <td colSpan={3} className="px-4 py-8 text-center text-slate-500">
+                    No privileged groups assigned.
+                  </td>
+                </tr>
+              )}
+              {assignments.map((a) =>
+                a.roles.map((r) => (
+                  <tr key={`${a.groupId}-${r.id}`} className="hover:bg-slate-50">
+                    <td className="px-4 py-3">
+                      <Link href={`/groups?id=${a.groupId}`} className="text-blue-600 hover:underline">
+                        {a.name}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3 text-slate-900">{r.name}</td>
+                    <td className="px-4 py-3">
+                      <button
+                        type="button"
+                        className="text-red-500 hover:text-red-700 transition-colors"
+                        onClick={() => handleRemove(a.groupId, r.id)}
+                        aria-label={`Remove role ${r.name} from ${a.name}`}
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </td>
+                  </tr>
+                )),
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/settings/group-roles-panel.tsx
+++ b/frontend/components/settings/group-roles-panel.tsx
@@ -1,10 +1,15 @@
 ﻿"use client"
 
-import { useState, useTransition } from "react"
 import { Trash2 } from "lucide-react"
-import { addGroupRoleAction, removeGroupRoleAction } from "@/app/settings/actions"
-import type { GroupRoleAssignmentDto, RoleDto } from "@/lib/settings/types"
 import Link from "next/link"
+import { useCallback, useState, useTransition } from "react"
+import {
+  addGroupRoleAction,
+  removeGroupRoleAction,
+  searchSettingsGroupsAction,
+} from "@/app/settings/actions"
+import { SettingsTypeahead } from "@/components/settings/settings-typeahead"
+import type { GroupRoleAssignmentDto, RoleDto } from "@/lib/settings/types"
 
 interface Props {
   initialAssignments: GroupRoleAssignmentDto[]
@@ -18,6 +23,8 @@ export function GroupRolesPanel({ initialAssignments, availableRoles }: Props) {
   const [selectedRoleId, setSelectedRoleId] = useState<number | "">("")
   const [error, setError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
+
+  const fetchGroups = useCallback((query: string) => searchSettingsGroupsAction(query), [])
 
   async function handleAdd(e: React.FormEvent) {
     e.preventDefault()
@@ -42,7 +49,14 @@ export function GroupRolesPanel({ initialAssignments, availableRoles }: Props) {
                 : a,
             )
           }
-          return [...prev, { groupId: selectedGroupId, name: groupSearch, roles: [{ id: role.id, name: role.name }] }]
+          return [
+            ...prev,
+            {
+              groupId: selectedGroupId,
+              name: groupSearch,
+              roles: [{ id: role.id, name: role.name }],
+            },
+          ]
         })
         setGroupSearch("")
         setSelectedGroupId(null)
@@ -72,41 +86,34 @@ export function GroupRolesPanel({ initialAssignments, availableRoles }: Props) {
   return (
     <div className="space-y-6">
       <h2 className="text-2xl font-bold font-serif text-slate-800">Group Roles</h2>
-      
+
       <div className="space-y-4">
         <h3 className="text-xl font-semibold text-slate-800">Add Privileged Group</h3>
 
         {error && (
-          <div className="bg-red-50 text-red-600 border border-red-200 p-4 rounded-md">
-            {error}
-          </div>
+          <div className="bg-red-50 text-red-600 border border-red-200 p-4 rounded-md">{error}</div>
         )}
 
         <form onSubmit={handleAdd} className="space-y-4 max-w-xl">
+          <SettingsTypeahead
+            label="Group"
+            value={groupSearch}
+            selectedId={selectedGroupId}
+            onQueryChange={setGroupSearch}
+            onSelect={(item) => setSelectedGroupId(item.id)}
+            onClear={() => setSelectedGroupId(null)}
+            fetchResults={fetchGroups}
+          />
+
           <div className="space-y-2">
-            <label className="block text-sm font-semibold text-slate-700">Group</label>
-            <input
-              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="type to search..."
-              value={groupSearch}
-              onChange={(e) => setGroupSearch(e.target.value)}
-            />
-          </div>
-          
-          <div className="space-y-2">
-            <label className="block text-sm font-semibold text-slate-700">Group ID</label>
-            <input
-              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              type="number"
-              placeholder="Group ID"
-              value={selectedGroupId ?? ""}
-              onChange={(e) => setSelectedGroupId(e.target.value ? Number(e.target.value) : null)}
-            />
-          </div>
-          
-          <div className="space-y-2">
-            <label className="block text-sm font-semibold text-slate-700">Role</label>
+            <label
+              htmlFor="group-role-select"
+              className="block text-sm font-semibold text-slate-700"
+            >
+              Role
+            </label>
             <select
+              id="group-role-select"
               className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
               value={selectedRoleId}
               onChange={(e) => setSelectedRoleId(e.target.value ? Number(e.target.value) : "")}
@@ -121,10 +128,10 @@ export function GroupRolesPanel({ initialAssignments, availableRoles }: Props) {
                 ))}
             </select>
           </div>
-          
-          <button 
+
+          <button
             className="px-4 py-2 bg-blue-500 text-white rounded-md text-sm font-medium hover:bg-blue-600 transition-colors disabled:opacity-50"
-            type="submit" 
+            type="submit"
             disabled={isPending}
           >
             Save
@@ -155,7 +162,10 @@ export function GroupRolesPanel({ initialAssignments, availableRoles }: Props) {
                 a.roles.map((r) => (
                   <tr key={`${a.groupId}-${r.id}`} className="hover:bg-slate-50">
                     <td className="px-4 py-3">
-                      <Link href={`/groups?id=${a.groupId}`} className="text-blue-600 hover:underline">
+                      <Link
+                        href={`/groups?id=${a.groupId}`}
+                        className="text-blue-600 hover:underline"
+                      >
                         {a.name}
                       </Link>
                     </td>

--- a/frontend/components/settings/roles-panel.test.tsx
+++ b/frontend/components/settings/roles-panel.test.tsx
@@ -1,0 +1,88 @@
+﻿import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { createRoleAction, deleteRoleAction, updateRolePermissionAction } from "@/app/settings/actions"
+import { RolesPanel } from "./roles-panel"
+import type { PermissionDto, RoleDto } from "@/lib/settings/types"
+
+vi.mock("@/app/settings/actions", () => ({
+  createRoleAction: vi.fn(),
+  deleteRoleAction: vi.fn(),
+  updateRolePermissionAction: vi.fn(),
+}))
+
+const PERMISSIONS: PermissionDto[] = [
+  { id: 4, name: "Edit Role Permissions" },
+  { id: 5, name: "Manage Global Site Settings" },
+]
+
+const INITIAL_ROLES: RoleDto[] = [
+  { id: 1, name: "Administrator", permissions: PERMISSIONS },
+  { id: 2, name: "User", permissions: [] },
+  { id: 10, name: "Manager", permissions: [{ id: 4, name: "Edit Role Permissions" }] },
+]
+
+describe("RolesPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(window, "confirm").mockReturnValue(true)
+  })
+
+  it("renders roles as columns and permissions as rows", () => {
+    render(<RolesPanel initialRoles={INITIAL_ROLES} permissions={PERMISSIONS} />)
+    // Roles as column headers
+    expect(screen.getByText("Administrator")).toBeInTheDocument()
+    expect(screen.getByText("Manager")).toBeInTheDocument()
+    // Permissions as row headers
+    expect(screen.getAllByText("Edit Role Permissions")[0]).toBeInTheDocument()
+
+    // Manager should have perm 4 checked
+    const checkbox = screen.getByLabelText(/edit role permissions for manager/i) as HTMLInputElement
+    expect(checkbox).toBeInTheDocument()
+    expect(checkbox.checked).toBe(true)
+  })
+
+  it("toggles permission optimistically and calls the server action", async () => {
+    const user = userEvent.setup()
+    vi.mocked(updateRolePermissionAction).mockResolvedValueOnce({ data: {} })
+
+    render(<RolesPanel initialRoles={INITIAL_ROLES} permissions={PERMISSIONS} />)
+
+    // Toggle on for User (id=2, perm id=4)
+    const checkbox = screen.getByLabelText(/edit role permissions for user/i)
+    await user.click(checkbox)
+
+    await waitFor(() => {
+      expect(updateRolePermissionAction).toHaveBeenCalledWith(2, 4, true)
+    })
+  })
+
+  it("reverts permission on server failure", async () => {
+    const user = userEvent.setup()
+    vi.mocked(updateRolePermissionAction).mockResolvedValueOnce({ error: "Access denied" })
+
+    render(<RolesPanel initialRoles={INITIAL_ROLES} permissions={PERMISSIONS} />)
+
+    const checkbox = screen.getByLabelText(/edit role permissions for manager/i) as HTMLInputElement
+    await user.click(checkbox)
+
+    await waitFor(() => {
+      expect(screen.getByText("Access denied")).toBeInTheDocument()
+      expect(checkbox.checked).toBe(true) // reverted
+    })
+  })
+
+  it("deletes a non-protected role via link click", async () => {
+    const user = userEvent.setup()
+    vi.mocked(deleteRoleAction).mockResolvedValueOnce({ data: {} })
+
+    render(<RolesPanel initialRoles={INITIAL_ROLES} permissions={PERMISSIONS} />)
+
+    const deleteLink = screen.getByRole("link", { name: /delete role manager/i })
+    await user.click(deleteLink)
+
+    await waitFor(() => {
+      expect(deleteRoleAction).toHaveBeenCalledWith(10)
+    })
+  })
+})

--- a/frontend/components/settings/roles-panel.test.tsx
+++ b/frontend/components/settings/roles-panel.test.tsx
@@ -1,4 +1,4 @@
-﻿import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { createRoleAction, deleteRoleAction, updateRolePermissionAction } from "@/app/settings/actions"
@@ -78,8 +78,8 @@ describe("RolesPanel", () => {
 
     render(<RolesPanel initialRoles={INITIAL_ROLES} permissions={PERMISSIONS} />)
 
-    const deleteLink = screen.getByRole("link", { name: /delete role manager/i })
-    await user.click(deleteLink)
+    const deleteBtn = screen.getByRole("button", { name: /delete role manager/i })
+    await user.click(deleteBtn)
 
     await waitFor(() => {
       expect(deleteRoleAction).toHaveBeenCalledWith(10)

--- a/frontend/components/settings/roles-panel.test.tsx
+++ b/frontend/components/settings/roles-panel.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { createRoleAction, deleteRoleAction, updateRolePermissionAction } from "@/app/settings/actions"
-import { RolesPanel } from "./roles-panel"
+import { deleteRoleAction, updateRolePermissionAction } from "@/app/settings/actions"
 import type { PermissionDto, RoleDto } from "@/lib/settings/types"
+import { RolesPanel } from "./roles-panel"
 
 vi.mock("@/app/settings/actions", () => ({
   createRoleAction: vi.fn(),

--- a/frontend/components/settings/roles-panel.tsx
+++ b/frontend/components/settings/roles-panel.tsx
@@ -1,6 +1,5 @@
 ﻿"use client"
 
-import { Trash2 } from "lucide-react"
 import { useOptimistic, useState, useTransition } from "react"
 import {
   createRoleAction,
@@ -93,15 +92,16 @@ export function RolesPanel({ initialRoles, permissions }: Props) {
       <h2 className="text-[28px] font-bold font-serif text-[#2c3e50]">Role Configuration</h2>
 
       {error && (
-        <div className="bg-red-50 text-red-600 border border-red-200 p-4 rounded-md">
-          {error}
-        </div>
+        <div className="bg-red-50 text-red-600 border border-red-200 p-4 rounded-md">{error}</div>
       )}
 
       <form onSubmit={handleCreateRole} className="space-y-1">
-        <label className="block text-[13px] font-bold text-gray-800">Add a New Role</label>
+        <label htmlFor="new-role-name" className="block text-[13px] font-bold text-gray-800">
+          Add a New Role
+        </label>
         <div className="flex w-full max-w-[300px] items-center space-x-0">
           <input
+            id="new-role-name"
             className="flex-1 rounded-l border border-gray-300 bg-white px-3 py-1.5 text-[13px] focus:outline-none focus:border-blue-500"
             type="text"
             placeholder="executive"
@@ -109,9 +109,9 @@ export function RolesPanel({ initialRoles, permissions }: Props) {
             onChange={(e) => setNewRoleName(e.target.value)}
             required
           />
-          <button 
+          <button
             className="px-4 py-1.5 bg-[#4a85e6] text-white rounded-r border border-[#4a85e6] text-[13px] font-medium hover:bg-blue-600 transition-colors disabled:opacity-50"
-            type="submit" 
+            type="submit"
             disabled={isPending}
           >
             Save
@@ -123,9 +123,15 @@ export function RolesPanel({ initialRoles, permissions }: Props) {
         <table className="w-full text-[13px] text-left" aria-label="role permissions matrix">
           <thead>
             <tr className="border-b border-gray-300">
-              <th scope="col" className="py-2 font-bold text-gray-800 w-64">Permission</th>
+              <th scope="col" className="py-2 font-bold text-gray-800 w-64">
+                Permission
+              </th>
               {roles.map((role) => (
-                <th scope="col" key={role.id} className="py-2 font-bold text-gray-800 text-center whitespace-nowrap">
+                <th
+                  scope="col"
+                  key={role.id}
+                  className="py-2 font-bold text-gray-800 text-center whitespace-nowrap"
+                >
                   {role.name}
                   {!isProtected(role) && (
                     <button
@@ -143,8 +149,13 @@ export function RolesPanel({ initialRoles, permissions }: Props) {
           </thead>
           <tbody>
             {permissions.map((perm) => (
-              <tr key={perm.id} className="border-b border-gray-200 last:border-b-0 hover:bg-gray-50 transition-colors">
-                <th scope="row" className="py-2.5 font-bold text-gray-800">{perm.name}</th>
+              <tr
+                key={perm.id}
+                className="border-b border-gray-200 last:border-b-0 hover:bg-gray-50 transition-colors"
+              >
+                <th scope="row" className="py-2.5 font-bold text-gray-800">
+                  {perm.name}
+                </th>
                 {roles.map((role) => {
                   const checked = hasPermission(role, perm.id)
                   const isAdmin = role.name === "Administrator"

--- a/frontend/components/settings/roles-panel.tsx
+++ b/frontend/components/settings/roles-panel.tsx
@@ -1,0 +1,172 @@
+﻿"use client"
+
+import { Trash2 } from "lucide-react"
+import { useOptimistic, useState, useTransition } from "react"
+import {
+  createRoleAction,
+  deleteRoleAction,
+  updateRolePermissionAction,
+} from "@/app/settings/actions"
+import type { PermissionDto, RoleDto } from "@/lib/settings/types"
+
+interface Props {
+  initialRoles: RoleDto[]
+  permissions: PermissionDto[]
+}
+
+const PROTECTED_IDS = new Set([1, 5])
+const PROTECTED_NAMES = new Set(["Administrator", "Director"])
+
+function isProtected(role: RoleDto) {
+  return PROTECTED_IDS.has(role.id) || PROTECTED_NAMES.has(role.name)
+}
+
+export function RolesPanel({ initialRoles, permissions }: Props) {
+  const [roles, setRoles] = useOptimistic<RoleDto[]>(initialRoles)
+  const [newRoleName, setNewRoleName] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function hasPermission(role: RoleDto, permId: number) {
+    return role.name === "Administrator" || role.permissions.some((p) => p.id === permId)
+  }
+
+  function handleToggle(roleId: number, permId: number, currentChecked: boolean) {
+    startTransition(async () => {
+      setError(null)
+      const next = !currentChecked
+      setRoles((prev) =>
+        prev.map((r) => {
+          if (r.id !== roleId) return r
+          const perms = next
+            ? [...r.permissions, { id: permId, name: "" }]
+            : r.permissions.filter((p) => p.id !== permId)
+          return { ...r, permissions: perms }
+        }),
+      )
+      const res = await updateRolePermissionAction(roleId, permId, next)
+      if (res && "error" in res) {
+        setError(res.error as string)
+        setRoles((prev) =>
+          prev.map((r) => {
+            if (r.id !== roleId) return r
+            const perms = !next
+              ? [...r.permissions, { id: permId, name: "" }]
+              : r.permissions.filter((p) => p.id !== permId)
+            return { ...r, permissions: perms }
+          }),
+        )
+      }
+    })
+  }
+
+  function handleDeleteRole(roleId: number) {
+    if (!confirm("Are you sure you want to remove this?")) return
+    startTransition(async () => {
+      setError(null)
+      setRoles((prev) => prev.filter((r) => r.id !== roleId))
+      const res = await deleteRoleAction(roleId)
+      if (res && "error" in res) {
+        setError(res.error as string)
+        setRoles(initialRoles)
+      }
+    })
+  }
+
+  function handleCreateRole(e: React.FormEvent) {
+    e.preventDefault()
+    if (!newRoleName.trim()) return
+    startTransition(async () => {
+      setError(null)
+      const res = await createRoleAction({ name: newRoleName.trim() })
+      if (res && "error" in res) {
+        setError(res.error as string)
+      } else if (res && "data" in res) {
+        setRoles((prev) => [...prev, res.data as RoleDto])
+        setNewRoleName("")
+      }
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-[28px] font-bold font-serif text-[#2c3e50]">Role Configuration</h2>
+
+      {error && (
+        <div className="bg-red-50 text-red-600 border border-red-200 p-4 rounded-md">
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleCreateRole} className="space-y-1">
+        <label className="block text-[13px] font-bold text-gray-800">Add a New Role</label>
+        <div className="flex w-full max-w-[300px] items-center space-x-0">
+          <input
+            className="flex-1 rounded-l border border-gray-300 bg-white px-3 py-1.5 text-[13px] focus:outline-none focus:border-blue-500"
+            type="text"
+            placeholder="executive"
+            value={newRoleName}
+            onChange={(e) => setNewRoleName(e.target.value)}
+            required
+          />
+          <button 
+            className="px-4 py-1.5 bg-[#4a85e6] text-white rounded-r border border-[#4a85e6] text-[13px] font-medium hover:bg-blue-600 transition-colors disabled:opacity-50"
+            type="submit" 
+            disabled={isPending}
+          >
+            Save
+          </button>
+        </div>
+      </form>
+
+      <div className="w-full mt-4">
+        <table className="w-full text-[13px] text-left" aria-label="role permissions matrix">
+          <thead>
+            <tr className="border-b border-gray-300">
+              <th scope="col" className="py-2 font-bold text-gray-800 w-64">Permission</th>
+              {roles.map((role) => (
+                <th scope="col" key={role.id} className="py-2 font-bold text-gray-800 text-center whitespace-nowrap">
+                  {role.name}
+                  {!isProtected(role) && (
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteRole(role.id)}
+                      aria-label={`Delete role ${role.name}`}
+                      className="ml-2 text-blue-600 hover:text-blue-800 inline-flex align-middle"
+                    >
+                      <i className="fas fa-trash"></i>
+                    </button>
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {permissions.map((perm) => (
+              <tr key={perm.id} className="border-b border-gray-200 last:border-b-0 hover:bg-gray-50 transition-colors">
+                <th scope="row" className="py-2.5 font-bold text-gray-800">{perm.name}</th>
+                {roles.map((role) => {
+                  const checked = hasPermission(role, perm.id)
+                  const isAdmin = role.name === "Administrator"
+                  return (
+                    <td key={role.id} className="py-2.5 text-center align-middle">
+                      <input
+                        className="w-[14px] h-[14px] text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 disabled:opacity-50 cursor-pointer"
+                        id={`${role.id}-${perm.id}`}
+                        type="checkbox"
+                        checked={checked}
+                        disabled={isAdmin || isPending}
+                        aria-label={`${perm.name} for ${role.name}`}
+                        onChange={() => !isAdmin && handleToggle(role.id, perm.id, checked)}
+                      />
+                    </td>
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/settings/search-settings-panel.tsx
+++ b/frontend/components/settings/search-settings-panel.tsx
@@ -1,7 +1,10 @@
 ﻿"use client"
 
 import { useState, useTransition } from "react"
-import { updateSearchReportTypeTextAction, updateSearchVisibilityAction } from "@/app/settings/actions"
+import {
+  updateSearchReportTypeTextAction,
+  updateSearchVisibilityAction,
+} from "@/app/settings/actions"
 import type { SearchSettingsDto } from "@/lib/settings/types"
 
 interface Props {
@@ -15,19 +18,19 @@ export function SearchSettingsPanel({ initialData }: Props) {
 
   // Track unsaved override names locally
   const [overrideInputs, setOverrideInputs] = useState<Record<number, string>>(
-    Object.fromEntries(initialData.reportTypes.map((t) => [t.id, t.shortName ?? ""]))
+    Object.fromEntries(initialData.reportTypes.map((t) => [t.id, t.shortName ?? ""])),
   )
 
   function handleVisibilityToggle(type: string, visible: boolean, reportTypeId?: number) {
     const prev = data
-    
+
     // Optimistic update
     setData((current) => {
       if (reportTypeId !== undefined) {
         return {
           ...current,
           reportTypes: current.reportTypes.map((t) =>
-            t.id === reportTypeId ? { ...t, visible } : t
+            t.id === reportTypeId ? { ...t, visible } : t,
           ),
         }
       }
@@ -61,7 +64,7 @@ export function SearchSettingsPanel({ initialData }: Props) {
         setData((current) => ({
           ...current,
           reportTypes: current.reportTypes.map((t) =>
-            t.id === reportTypeId ? { ...t, shortName: text ?? "" } : t
+            t.id === reportTypeId ? { ...t, shortName: text ?? "" } : t,
           ),
         }))
       }
@@ -79,11 +82,9 @@ export function SearchSettingsPanel({ initialData }: Props) {
   return (
     <div className="space-y-10">
       <h2 className="text-[28px] font-bold font-serif text-[#2c3e50]">Search Settings</h2>
-      
+
       {error && (
-        <div className="bg-red-50 text-red-600 border border-red-200 p-4 rounded-md">
-          {error}
-        </div>
+        <div className="bg-red-50 text-red-600 border border-red-200 p-4 rounded-md">{error}</div>
       )}
 
       <div className="space-y-4">
@@ -98,7 +99,10 @@ export function SearchSettingsPanel({ initialData }: Props) {
             </thead>
             <tbody>
               {objects.map((obj) => (
-                <tr key={obj.key} className="border-b border-gray-200 last:border-b-0 hover:bg-gray-50 transition-colors">
+                <tr
+                  key={obj.key}
+                  className="border-b border-gray-200 last:border-b-0 hover:bg-gray-50 transition-colors"
+                >
                   <td className="py-2.5 text-center align-middle">
                     <label className="relative inline-flex items-center cursor-pointer opacity-90 hover:opacity-100">
                       <input
@@ -132,7 +136,10 @@ export function SearchSettingsPanel({ initialData }: Props) {
             </thead>
             <tbody>
               {data.reportTypes.map((t) => (
-                <tr key={t.id} className="border-b border-gray-200 last:border-b-0 hover:bg-gray-50 transition-colors">
+                <tr
+                  key={t.id}
+                  className="border-b border-gray-200 last:border-b-0 hover:bg-gray-50 transition-colors"
+                >
                   <td className="py-2.5 text-center align-middle">
                     <label className="relative inline-flex items-center cursor-pointer opacity-90 hover:opacity-100">
                       <input
@@ -145,9 +152,7 @@ export function SearchSettingsPanel({ initialData }: Props) {
                       <div className="w-10 h-5 bg-gray-300 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-[#3b82f6]"></div>
                     </label>
                   </td>
-                  <td className="py-2.5 text-gray-800 font-medium">
-                    {t.name}
-                  </td>
+                  <td className="py-2.5 text-gray-800 font-medium">{t.name}</td>
                   <td className="py-2.5">
                     <div className="flex w-full items-center space-x-2">
                       <input
@@ -160,9 +165,10 @@ export function SearchSettingsPanel({ initialData }: Props) {
                         }
                         disabled={isPending}
                       />
-                      <button 
+                      <button
+                        type="button"
                         className="px-4 py-1 bg-[#4a85e6] text-white rounded text-[13px] hover:bg-blue-600 transition-colors disabled:opacity-50 font-medium"
-                        onClick={() => handleSaveOverride(t.id)} 
+                        onClick={() => handleSaveOverride(t.id)}
                         disabled={isPending}
                       >
                         Save

--- a/frontend/components/settings/search-settings-panel.tsx
+++ b/frontend/components/settings/search-settings-panel.tsx
@@ -1,0 +1,180 @@
+﻿"use client"
+
+import { useState, useTransition } from "react"
+import { updateSearchReportTypeTextAction, updateSearchVisibilityAction } from "@/app/settings/actions"
+import type { SearchSettingsDto } from "@/lib/settings/types"
+
+interface Props {
+  initialData: SearchSettingsDto
+}
+
+export function SearchSettingsPanel({ initialData }: Props) {
+  const [data, setData] = useState(initialData)
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  // Track unsaved override names locally
+  const [overrideInputs, setOverrideInputs] = useState<Record<number, string>>(
+    Object.fromEntries(initialData.reportTypes.map((t) => [t.id, t.shortName ?? ""]))
+  )
+
+  function handleVisibilityToggle(type: string, visible: boolean, reportTypeId?: number) {
+    const prev = data
+    
+    // Optimistic update
+    setData((current) => {
+      if (reportTypeId !== undefined) {
+        return {
+          ...current,
+          reportTypes: current.reportTypes.map((t) =>
+            t.id === reportTypeId ? { ...t, visible } : t
+          ),
+        }
+      }
+      return {
+        ...current,
+        visibility: {
+          ...current.visibility,
+          [type]: visible ? "Y" : "N",
+        },
+      }
+    })
+
+    startTransition(async () => {
+      setError(null)
+      const res = await updateSearchVisibilityAction(type, visible, reportTypeId)
+      if (res && "error" in res) {
+        setError(res.error as string)
+        setData(prev)
+      }
+    })
+  }
+
+  function handleSaveOverride(reportTypeId: number) {
+    const text = overrideInputs[reportTypeId]?.trim() || null
+    startTransition(async () => {
+      setError(null)
+      const res = await updateSearchReportTypeTextAction(reportTypeId, text)
+      if (res && "error" in res) {
+        setError(res.error as string)
+      } else {
+        setData((current) => ({
+          ...current,
+          reportTypes: current.reportTypes.map((t) =>
+            t.id === reportTypeId ? { ...t, shortName: text ?? "" } : t
+          ),
+        }))
+      }
+    })
+  }
+
+  const objects = [
+    { key: "users", label: "Users" },
+    { key: "groups", label: "Groups" },
+    { key: "terms", label: "Terms" },
+    { key: "initiatives", label: "Initiatives" },
+    { key: "collections", label: "Collections" },
+  ]
+
+  return (
+    <div className="space-y-10">
+      <h2 className="text-[28px] font-bold font-serif text-[#2c3e50]">Search Settings</h2>
+      
+      {error && (
+        <div className="bg-red-50 text-red-600 border border-red-200 p-4 rounded-md">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-4">
+        <h3 className="text-xl font-bold font-serif text-[#2c3e50]">Visible Objects</h3>
+        <div className="w-full">
+          <table className="w-full text-[13px] text-left">
+            <thead>
+              <tr className="border-b border-gray-300">
+                <th className="py-2 font-bold text-gray-800 w-16"></th>
+                <th className="py-2 font-bold text-gray-800">Object</th>
+              </tr>
+            </thead>
+            <tbody>
+              {objects.map((obj) => (
+                <tr key={obj.key} className="border-b border-gray-200 last:border-b-0 hover:bg-gray-50 transition-colors">
+                  <td className="py-2.5 text-center align-middle">
+                    <label className="relative inline-flex items-center cursor-pointer opacity-90 hover:opacity-100">
+                      <input
+                        type="checkbox"
+                        className="sr-only peer"
+                        checked={data.visibility[obj.key] === "Y"}
+                        disabled={isPending}
+                        onChange={(e) => handleVisibilityToggle(obj.key, e.target.checked)}
+                      />
+                      <div className="w-10 h-5 bg-gray-300 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-[#3b82f6]"></div>
+                    </label>
+                  </td>
+                  <td className="py-2.5 text-gray-800 font-medium">{obj.label}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <h3 className="text-xl font-bold font-serif text-[#2c3e50]">Visible Report Types</h3>
+        <div className="w-full">
+          <table className="w-full text-[13px] text-left">
+            <thead>
+              <tr className="border-b border-gray-300">
+                <th className="py-2 font-bold text-gray-800 w-16"></th>
+                <th className="py-2 font-bold text-gray-800">Report Type</th>
+                <th className="py-2 font-bold text-gray-800 w-[400px]">Search Name Override</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.reportTypes.map((t) => (
+                <tr key={t.id} className="border-b border-gray-200 last:border-b-0 hover:bg-gray-50 transition-colors">
+                  <td className="py-2.5 text-center align-middle">
+                    <label className="relative inline-flex items-center cursor-pointer opacity-90 hover:opacity-100">
+                      <input
+                        type="checkbox"
+                        className="sr-only peer"
+                        checked={t.visible}
+                        disabled={isPending}
+                        onChange={(e) => handleVisibilityToggle("reports", e.target.checked, t.id)}
+                      />
+                      <div className="w-10 h-5 bg-gray-300 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-[#3b82f6]"></div>
+                    </label>
+                  </td>
+                  <td className="py-2.5 text-gray-800 font-medium">
+                    {t.name}
+                  </td>
+                  <td className="py-2.5">
+                    <div className="flex w-full items-center space-x-2">
+                      <input
+                        type="text"
+                        className="flex-1 rounded border border-gray-300 bg-white px-3 py-1 text-[13px] text-gray-700 placeholder-gray-400 focus:outline-none focus:border-blue-500"
+                        placeholder={t.name}
+                        value={overrideInputs[t.id] ?? ""}
+                        onChange={(e) =>
+                          setOverrideInputs((prev) => ({ ...prev, [t.id]: e.target.value }))
+                        }
+                        disabled={isPending}
+                      />
+                      <button 
+                        className="px-4 py-1 bg-[#4a85e6] text-white rounded text-[13px] hover:bg-blue-600 transition-colors disabled:opacity-50 font-medium"
+                        onClick={() => handleSaveOverride(t.id)} 
+                        disabled={isPending}
+                      >
+                        Save
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/settings/settings-tab-controller.tsx
+++ b/frontend/components/settings/settings-tab-controller.tsx
@@ -1,6 +1,6 @@
 ﻿"use client"
 
-import { useEffect, useRef, type ReactNode } from "react"
+import { type ReactNode, useEffect, useRef } from "react"
 
 interface Props {
   defaultTab: string
@@ -13,14 +13,14 @@ export function SettingsTabController({ defaultTab, children }: Props) {
   function activateTab(tabId: string) {
     const container = containerRef.current
     if (!container) return
-    
+
     // Hide all panels by adding 'hidden'
     const panels = container.querySelectorAll<HTMLElement>(".panel-tab-data")
     panels.forEach((p) => {
       p.classList.add("hidden")
       p.classList.remove("block")
     })
-    
+
     // Show target
     const target = container.querySelector<HTMLElement>(`#${tabId}`)
     if (target) {
@@ -33,7 +33,7 @@ export function SettingsTabController({ defaultTab, children }: Props) {
       const link = a as HTMLAnchorElement
       const isActive = link.hash === `#${tabId}`
       const iconSpan = link.querySelector("span")
-      
+
       if (isActive) {
         link.classList.add("text-[#485fc7]", "bg-[#f5f5f5]")
         link.classList.remove("text-[#363636]", "hover:bg-[#f5f5f5]")
@@ -67,7 +67,7 @@ export function SettingsTabController({ defaultTab, children }: Props) {
 
     // Intercept panel-tab link clicks
     const navLinks = document.querySelectorAll<HTMLAnchorElement>("a.panel-tab")
-    const clickHandlers = Array.from(navLinks).map(link => {
+    const clickHandlers = Array.from(navLinks).map((link) => {
       const handler = (e: Event) => {
         e.preventDefault()
         const id = link.hash.replace("#", "")
@@ -86,9 +86,5 @@ export function SettingsTabController({ defaultTab, children }: Props) {
     }
   }, [defaultTab])
 
-  return (
-    <div ref={containerRef}>
-      {children}
-    </div>
-  )
+  return <div ref={containerRef}>{children}</div>
 }

--- a/frontend/components/settings/settings-tab-controller.tsx
+++ b/frontend/components/settings/settings-tab-controller.tsx
@@ -1,0 +1,94 @@
+﻿"use client"
+
+import { useEffect, useRef, type ReactNode } from "react"
+
+interface Props {
+  defaultTab: string
+  children: ReactNode
+}
+
+export function SettingsTabController({ defaultTab, children }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  function activateTab(tabId: string) {
+    const container = containerRef.current
+    if (!container) return
+    
+    // Hide all panels by adding 'hidden'
+    const panels = container.querySelectorAll<HTMLElement>(".panel-tab-data")
+    panels.forEach((p) => {
+      p.classList.add("hidden")
+      p.classList.remove("block")
+    })
+    
+    // Show target
+    const target = container.querySelector<HTMLElement>(`#${tabId}`)
+    if (target) {
+      target.classList.remove("hidden")
+      target.classList.add("block")
+    }
+
+    // Update nav active state
+    document.querySelectorAll(".panel-tab").forEach((a) => {
+      const link = a as HTMLAnchorElement
+      const isActive = link.hash === `#${tabId}`
+      const iconSpan = link.querySelector("span")
+      
+      if (isActive) {
+        link.classList.add("text-[#485fc7]", "bg-[#f5f5f5]")
+        link.classList.remove("text-[#363636]", "hover:bg-[#f5f5f5]")
+        if (iconSpan) {
+          iconSpan.classList.add("text-[#485fc7]")
+          iconSpan.classList.remove("text-[#4a4a4a]")
+        }
+      } else {
+        link.classList.remove("text-[#485fc7]", "bg-[#f5f5f5]")
+        link.classList.add("text-[#363636]", "hover:bg-[#f5f5f5]")
+        if (iconSpan) {
+          iconSpan.classList.remove("text-[#485fc7]")
+          iconSpan.classList.add("text-[#4a4a4a]")
+        }
+      }
+    })
+  }
+
+  useEffect(() => {
+    // Read hash on mount
+    const hash = window.location.hash.replace("#", "") || defaultTab
+    activateTab(hash)
+
+    // Listen for hash changes
+    const handleHashChange = () => {
+      const id = window.location.hash.replace("#", "") || defaultTab
+      activateTab(id)
+    }
+
+    window.addEventListener("hashchange", handleHashChange)
+
+    // Intercept panel-tab link clicks
+    const navLinks = document.querySelectorAll<HTMLAnchorElement>("a.panel-tab")
+    const clickHandlers = Array.from(navLinks).map(link => {
+      const handler = (e: Event) => {
+        e.preventDefault()
+        const id = link.hash.replace("#", "")
+        window.history.pushState(null, "", `#${id}`)
+        activateTab(id)
+      }
+      link.addEventListener("click", handler)
+      return { link, handler }
+    })
+
+    return () => {
+      window.removeEventListener("hashchange", handleHashChange)
+      clickHandlers.forEach(({ link, handler }) => {
+        link.removeEventListener("click", handler)
+      })
+    }
+  }, [defaultTab])
+
+  return (
+    <div ref={containerRef}>
+      {children}
+    </div>
+  )
+}

--- a/frontend/components/settings/settings-typeahead.tsx
+++ b/frontend/components/settings/settings-typeahead.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import { useEffect, useId, useState } from "react"
+
+export type SettingsTypeaheadItem = {
+  id: number
+  name: string
+  description?: string | null
+}
+
+interface SettingsTypeaheadProps {
+  label: string
+  placeholder?: string
+  value: string
+  selectedId: number | null
+  onQueryChange: (query: string) => void
+  onSelect: (item: SettingsTypeaheadItem) => void
+  onClear: () => void
+  fetchResults: (query: string) => Promise<SettingsTypeaheadItem[]>
+}
+
+export function SettingsTypeahead({
+  label,
+  placeholder = "type to search...",
+  value,
+  selectedId,
+  onQueryChange,
+  onSelect,
+  onClear,
+  fetchResults,
+}: SettingsTypeaheadProps) {
+  const inputId = useId()
+  const [results, setResults] = useState<SettingsTypeaheadItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    const trimmed = value.trim()
+    if (!trimmed || selectedId !== null) {
+      setResults([])
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    const handle = window.setTimeout(() => {
+      void fetchResults(trimmed)
+        .then((items) => {
+          setResults(items)
+          setOpen(items.length > 0)
+        })
+        .catch(() => {
+          setResults([])
+          setOpen(false)
+        })
+        .finally(() => {
+          setLoading(false)
+        })
+    }, 280)
+
+    return () => {
+      window.clearTimeout(handle)
+    }
+  }, [value, selectedId, fetchResults])
+
+  return (
+    <div className="relative space-y-2">
+      <label htmlFor={inputId} className="block text-sm font-semibold text-slate-700">
+        {label}
+      </label>
+      <div className="flex gap-2">
+        <input
+          id={inputId}
+          className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder={placeholder}
+          value={value}
+          onChange={(e) => {
+            onClear()
+            onQueryChange(e.target.value)
+            setOpen(true)
+          }}
+          onFocus={() => {
+            if (results.length > 0) setOpen(true)
+          }}
+          autoComplete="off"
+        />
+        {value && (
+          <button
+            type="button"
+            className="shrink-0 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-600 hover:bg-slate-50"
+            onClick={() => {
+              onQueryChange("")
+              onClear()
+              setResults([])
+              setOpen(false)
+            }}
+            aria-label={`Clear ${label.toLowerCase()} search`}
+          >
+            Clear
+          </button>
+        )}
+      </div>
+      {loading && <p className="text-xs text-slate-500">Searching...</p>}
+      {open && results.length > 0 && (
+        <ul className="absolute z-10 mt-1 max-h-48 w-full overflow-auto rounded-md border border-slate-200 bg-white shadow-lg">
+          {results.map((item) => (
+            <li key={item.id}>
+              <button
+                type="button"
+                className="block w-full px-3 py-2 text-left text-sm hover:bg-slate-50"
+                onClick={() => {
+                  onSelect(item)
+                  onQueryChange(item.name)
+                  setOpen(false)
+                }}
+              >
+                <span className="font-medium text-slate-900">{item.name}</span>
+                {item.description ? (
+                  <span className="ml-2 text-slate-500">{item.description}</span>
+                ) : null}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {open && !loading && value.trim() && results.length === 0 && selectedId === null && (
+        <p className="text-xs text-slate-500">No matches found.</p>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/settings/site-messages-panel.test.tsx
+++ b/frontend/components/settings/site-messages-panel.test.tsx
@@ -28,8 +28,9 @@ describe("SiteMessagesPanel", () => {
     const user = userEvent.setup()
     render(<SiteMessagesPanel initialMessages={INITIAL_MESSAGES} />)
 
-    await user.click(screen.getByRole("button", { name: /add message/i }))
-    expect(screen.getByText("Message value is required.")).toBeInTheDocument()
+    await user.type(screen.getByPlaceholderText(/message content/i), "   ")
+    await user.click(screen.getByRole("button", { name: /^add$/i }))
+    expect(screen.getByText("Message content is required.")).toBeInTheDocument()
     expect(addSiteMessageAction).not.toHaveBeenCalled()
   })
 
@@ -41,13 +42,13 @@ describe("SiteMessagesPanel", () => {
 
     render(<SiteMessagesPanel initialMessages={INITIAL_MESSAGES} />)
 
-    await user.type(screen.getByRole("textbox", { name: /^message$/i }), "New Message")
-    await user.click(screen.getByRole("button", { name: /add message/i }))
+    await user.type(screen.getByPlaceholderText(/message content/i), "New Message")
+    await user.click(screen.getByRole("button", { name: /^add$/i }))
 
     await waitFor(() => {
       expect(addSiteMessageAction).toHaveBeenCalledWith({
         value: "New Message",
-        description: null,
+        description: undefined,
       })
       expect(screen.getByText("New Message")).toBeInTheDocument()
     })
@@ -61,8 +62,8 @@ describe("SiteMessagesPanel", () => {
 
     render(<SiteMessagesPanel initialMessages={INITIAL_MESSAGES} />)
 
-    await user.type(screen.getByRole("textbox", { name: /^message$/i }), "Another Message")
-    await user.click(screen.getByRole("button", { name: /add message/i }))
+    await user.type(screen.getByPlaceholderText(/message content/i), "Another Message")
+    await user.click(screen.getByRole("button", { name: /^add$/i }))
 
     await waitFor(() => {
       expect(screen.getByText("You do not have permission to view this content.")).toBeInTheDocument()
@@ -72,15 +73,20 @@ describe("SiteMessagesPanel", () => {
   it("deletes a message successfully", async () => {
     const user = userEvent.setup()
     vi.mocked(deleteSiteMessageAction).mockResolvedValueOnce({ data: {} })
+    
+    // Mock window.confirm
+    const confirmSpy = vi.spyOn(window, 'confirm').mockImplementation(() => true)
 
     render(<SiteMessagesPanel initialMessages={INITIAL_MESSAGES} />)
 
-    const deleteBtn = screen.getByRole("button", { name: /delete message: welcome to atlas/i })
+    const deleteBtn = screen.getByRole("button", { name: /delete message 1/i })
     await user.click(deleteBtn)
 
     await waitFor(() => {
       expect(deleteSiteMessageAction).toHaveBeenCalledWith(1)
       expect(screen.queryByText("Welcome to Atlas")).not.toBeInTheDocument()
     })
+    
+    confirmSpy.mockRestore()
   })
 })

--- a/frontend/components/settings/site-messages-panel.test.tsx
+++ b/frontend/components/settings/site-messages-panel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { addSiteMessageAction, deleteSiteMessageAction } from "@/app/settings/actions"
@@ -9,9 +9,7 @@ vi.mock("@/app/settings/actions", () => ({
   deleteSiteMessageAction: vi.fn(),
 }))
 
-const INITIAL_MESSAGES = [
-  { id: 1, value: "Welcome to Atlas", description: "Default banner" },
-]
+const INITIAL_MESSAGES = [{ id: 1, value: "Welcome to Atlas", description: "Default banner" }]
 
 describe("SiteMessagesPanel", () => {
   beforeEach(() => {
@@ -66,16 +64,18 @@ describe("SiteMessagesPanel", () => {
     await user.click(screen.getByRole("button", { name: /^add$/i }))
 
     await waitFor(() => {
-      expect(screen.getByText("You do not have permission to view this content.")).toBeInTheDocument()
+      expect(
+        screen.getByText("You do not have permission to view this content."),
+      ).toBeInTheDocument()
     })
   })
 
   it("deletes a message successfully", async () => {
     const user = userEvent.setup()
     vi.mocked(deleteSiteMessageAction).mockResolvedValueOnce({ data: {} })
-    
+
     // Mock window.confirm
-    const confirmSpy = vi.spyOn(window, 'confirm').mockImplementation(() => true)
+    const confirmSpy = vi.spyOn(window, "confirm").mockImplementation(() => true)
 
     render(<SiteMessagesPanel initialMessages={INITIAL_MESSAGES} />)
 
@@ -86,7 +86,7 @@ describe("SiteMessagesPanel", () => {
       expect(deleteSiteMessageAction).toHaveBeenCalledWith(1)
       expect(screen.queryByText("Welcome to Atlas")).not.toBeInTheDocument()
     })
-    
+
     confirmSpy.mockRestore()
   })
 })

--- a/frontend/components/settings/site-messages-panel.test.tsx
+++ b/frontend/components/settings/site-messages-panel.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { addSiteMessageAction, deleteSiteMessageAction } from "@/app/settings/actions"
+import { SiteMessagesPanel } from "./site-messages-panel"
+
+vi.mock("@/app/settings/actions", () => ({
+  addSiteMessageAction: vi.fn(),
+  deleteSiteMessageAction: vi.fn(),
+}))
+
+const INITIAL_MESSAGES = [
+  { id: 1, value: "Welcome to Atlas", description: "Default banner" },
+]
+
+describe("SiteMessagesPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders existing messages", () => {
+    render(<SiteMessagesPanel initialMessages={INITIAL_MESSAGES} />)
+    expect(screen.getByText("Welcome to Atlas")).toBeInTheDocument()
+    expect(screen.getByText("Default banner")).toBeInTheDocument()
+  })
+
+  it("shows validation error if adding an empty message", async () => {
+    const user = userEvent.setup()
+    render(<SiteMessagesPanel initialMessages={INITIAL_MESSAGES} />)
+
+    await user.click(screen.getByRole("button", { name: /add message/i }))
+    expect(screen.getByText("Message value is required.")).toBeInTheDocument()
+    expect(addSiteMessageAction).not.toHaveBeenCalled()
+  })
+
+  it("adds a message successfully and updates the list", async () => {
+    const user = userEvent.setup()
+    vi.mocked(addSiteMessageAction).mockResolvedValueOnce({
+      data: { id: 2, value: "New Message", description: null },
+    })
+
+    render(<SiteMessagesPanel initialMessages={INITIAL_MESSAGES} />)
+
+    await user.type(screen.getByRole("textbox", { name: /^message$/i }), "New Message")
+    await user.click(screen.getByRole("button", { name: /add message/i }))
+
+    await waitFor(() => {
+      expect(addSiteMessageAction).toHaveBeenCalledWith({
+        value: "New Message",
+        description: null,
+      })
+      expect(screen.getByText("New Message")).toBeInTheDocument()
+    })
+  })
+
+  it("displays server error when adding fails (e.g. forbidden)", async () => {
+    const user = userEvent.setup()
+    vi.mocked(addSiteMessageAction).mockResolvedValueOnce({
+      error: "You do not have permission to view this content.",
+    })
+
+    render(<SiteMessagesPanel initialMessages={INITIAL_MESSAGES} />)
+
+    await user.type(screen.getByRole("textbox", { name: /^message$/i }), "Another Message")
+    await user.click(screen.getByRole("button", { name: /add message/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("You do not have permission to view this content.")).toBeInTheDocument()
+    })
+  })
+
+  it("deletes a message successfully", async () => {
+    const user = userEvent.setup()
+    vi.mocked(deleteSiteMessageAction).mockResolvedValueOnce({ data: {} })
+
+    render(<SiteMessagesPanel initialMessages={INITIAL_MESSAGES} />)
+
+    const deleteBtn = screen.getByRole("button", { name: /delete message: welcome to atlas/i })
+    await user.click(deleteBtn)
+
+    await waitFor(() => {
+      expect(deleteSiteMessageAction).toHaveBeenCalledWith(1)
+      expect(screen.queryByText("Welcome to Atlas")).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/components/settings/site-messages-panel.tsx
+++ b/frontend/components/settings/site-messages-panel.tsx
@@ -1,7 +1,7 @@
 ﻿"use client"
 
-import { useState, useTransition } from "react"
 import { Trash2 } from "lucide-react"
+import { useState, useTransition } from "react"
 import { addSiteMessageAction, deleteSiteMessageAction } from "@/app/settings/actions"
 import type { SiteMessageDto } from "@/lib/settings/types"
 
@@ -54,11 +54,9 @@ export function SiteMessagesPanel({ initialMessages }: Props) {
   return (
     <div className="space-y-6">
       <h2 className="text-2xl font-bold font-serif text-slate-800">Site Messages</h2>
-      
+
       {error && (
-        <div className="bg-red-50 text-red-600 border border-red-200 p-4 rounded-md">
-          {error}
-        </div>
+        <div className="bg-red-50 text-red-600 border border-red-200 p-4 rounded-md">{error}</div>
       )}
 
       <form onSubmit={handleAdd} className="flex gap-2 w-full max-w-2xl">
@@ -81,9 +79,9 @@ export function SiteMessagesPanel({ initialMessages }: Props) {
             onChange={(e) => setNewDesc(e.target.value)}
           />
         </div>
-        <button 
+        <button
           className="h-10 px-4 py-2 bg-blue-500 text-white rounded-md text-sm font-medium hover:bg-blue-600 transition-colors disabled:opacity-50"
-          type="submit" 
+          type="submit"
           disabled={isPending}
         >
           Add

--- a/frontend/components/settings/site-messages-panel.tsx
+++ b/frontend/components/settings/site-messages-panel.tsx
@@ -1,0 +1,131 @@
+﻿"use client"
+
+import { useState, useTransition } from "react"
+import { Trash2 } from "lucide-react"
+import { addSiteMessageAction, deleteSiteMessageAction } from "@/app/settings/actions"
+import type { SiteMessageDto } from "@/lib/settings/types"
+
+interface Props {
+  initialMessages: SiteMessageDto[]
+}
+
+export function SiteMessagesPanel({ initialMessages }: Props) {
+  const [messages, setMessages] = useState<SiteMessageDto[]>(initialMessages)
+  const [newValue, setNewValue] = useState("")
+  const [newDesc, setNewDesc] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function handleAdd(e: React.FormEvent) {
+    e.preventDefault()
+    if (!newValue.trim()) {
+      setError("Message content is required.")
+      return
+    }
+    setError(null)
+    startTransition(async () => {
+      const res = await addSiteMessageAction({
+        value: newValue.trim(),
+        description: newDesc.trim() || undefined,
+      })
+      if (res && "error" in res) {
+        setError(res.error as string)
+      } else if (res && "data" in res) {
+        setMessages((prev) => [...prev, res.data as SiteMessageDto])
+        setNewValue("")
+        setNewDesc("")
+      }
+    })
+  }
+
+  function handleDelete(id: number) {
+    if (!confirm("Are you sure you want to remove this?")) return
+    startTransition(async () => {
+      setError(null)
+      const res = await deleteSiteMessageAction(id)
+      if (res && "error" in res) {
+        setError(res.error as string)
+      } else {
+        setMessages((prev) => prev.filter((m) => m.id !== id))
+      }
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-2xl font-bold font-serif text-slate-800">Site Messages</h2>
+      
+      {error && (
+        <div className="bg-red-50 text-red-600 border border-red-200 p-4 rounded-md">
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleAdd} className="flex gap-2 w-full max-w-2xl">
+        <div className="flex-1">
+          <input
+            className="w-full h-10 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            type="text"
+            placeholder="Message Content..."
+            value={newValue}
+            onChange={(e) => setNewValue(e.target.value)}
+            required
+          />
+        </div>
+        <div className="flex-1">
+          <input
+            className="w-full h-10 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            type="text"
+            placeholder="Description (optional)"
+            value={newDesc}
+            onChange={(e) => setNewDesc(e.target.value)}
+          />
+        </div>
+        <button 
+          className="h-10 px-4 py-2 bg-blue-500 text-white rounded-md text-sm font-medium hover:bg-blue-600 transition-colors disabled:opacity-50"
+          type="submit" 
+          disabled={isPending}
+        >
+          Add
+        </button>
+      </form>
+
+      <div className="overflow-x-auto border border-slate-200 rounded-md">
+        <table className="w-full text-sm text-left">
+          <thead className="bg-slate-50 border-b border-slate-200 text-slate-700">
+            <tr>
+              <th className="px-4 py-3 font-semibold">Message</th>
+              <th className="px-4 py-3 font-semibold">Description</th>
+              <th className="px-4 py-3 font-semibold w-24">Remove</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200 bg-white">
+            {messages.length === 0 && (
+              <tr>
+                <td colSpan={3} className="px-4 py-8 text-center text-slate-500">
+                  No site messages.
+                </td>
+              </tr>
+            )}
+            {messages.map((m) => (
+              <tr key={m.id} className="hover:bg-slate-50">
+                <td className="px-4 py-3 text-slate-900">{m.value}</td>
+                <td className="px-4 py-3 text-slate-700">{m.description ?? ""}</td>
+                <td className="px-4 py-3 text-center">
+                  <button
+                    type="button"
+                    className="text-red-500 hover:text-red-700 transition-colors"
+                    onClick={() => handleDelete(m.id)}
+                    aria-label={`Delete message ${m.id}`}
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/settings/tags-settings-panel.tsx
+++ b/frontend/components/settings/tags-settings-panel.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useTransition } from "react"
 import { createTagAction, deleteTagAction } from "@/app/settings/actions"
-import type { ParameterDto } from "@/lib/settings/types"
 import type { TagType } from "@/lib/settings/api"
+import type { ParameterDto } from "@/lib/settings/types"
 
 interface TagSectionProps {
   title: string
@@ -24,7 +24,10 @@ function TagSection({ title, tagType, initialItems, hasDescription = false }: Ta
     if (!newName.trim()) return
     startTransition(async () => {
       setError(null)
-      const res = await createTagAction(tagType, { name: newName.trim(), description: newDesc.trim() || undefined })
+      const res = await createTagAction(tagType, {
+        name: newName.trim(),
+        description: newDesc.trim() || undefined,
+      })
       if (res && "error" in res) {
         setError(res.error as string)
       } else if (res && "data" in res) {
@@ -51,13 +54,13 @@ function TagSection({ title, tagType, initialItems, hasDescription = false }: Ta
   return (
     <div className="mb-8 last:mb-0 space-y-2">
       <h4 className="text-[15px] font-bold text-gray-800">{title}</h4>
-      
+
       {error && (
         <div className="bg-red-50 text-red-600 border border-red-200 p-3 rounded-md text-sm">
           {error}
         </div>
       )}
-      
+
       <div className="w-full">
         <table className="w-full text-[13px] text-left" aria-label={title}>
           <thead>
@@ -71,15 +74,23 @@ function TagSection({ title, tagType, initialItems, hasDescription = false }: Ta
           <tbody>
             {items.length === 0 && (
               <tr>
-                <td colSpan={hasDescription ? 4 : 3} className="py-4 text-center text-gray-500 border-b border-gray-200">
+                <td
+                  colSpan={hasDescription ? 4 : 3}
+                  className="py-4 text-center text-gray-500 border-b border-gray-200"
+                >
                   No items.
                 </td>
               </tr>
             )}
             {items.map((item) => (
-              <tr key={item.id} className="border-b border-gray-200 last:border-b-0 hover:bg-gray-50 transition-colors">
+              <tr
+                key={item.id}
+                className="border-b border-gray-200 last:border-b-0 hover:bg-gray-50 transition-colors"
+              >
                 <td className="py-2.5 font-bold text-gray-800">{item.name}</td>
-                {hasDescription && <td className="py-2.5 text-gray-700">{item.description ?? ""}</td>}
+                {hasDescription && (
+                  <td className="py-2.5 text-gray-700">{item.description ?? ""}</td>
+                )}
                 <td className="py-2.5 text-gray-700">{item.used}</td>
                 <td className="py-2.5">
                   <button
@@ -96,7 +107,7 @@ function TagSection({ title, tagType, initialItems, hasDescription = false }: Ta
           </tbody>
         </table>
       </div>
-      
+
       <form onSubmit={handleAdd} className="flex max-w-[300px]">
         <input
           className="flex-1 rounded-l border border-gray-300 bg-white px-3 py-1.5 text-[13px] focus:outline-none focus:border-blue-500 placeholder-gray-400"
@@ -115,9 +126,9 @@ function TagSection({ title, tagType, initialItems, hasDescription = false }: Ta
             onChange={(e) => setNewDesc(e.target.value)}
           />
         )}
-        <button 
+        <button
           className="px-4 py-1.5 bg-[#4a85e6] text-white rounded-r border border-[#4a85e6] text-[13px] font-medium hover:bg-blue-600 transition-colors disabled:opacity-50"
-          type="submit" 
+          type="submit"
           disabled={isPending}
         >
           Add
@@ -153,14 +164,38 @@ export function TagsSettingsPanel({
   return (
     <div className="space-y-6">
       <h3 className="text-[28px] font-bold font-serif text-[#2c3e50] mb-8">Meta Fields</h3>
-      <TagSection title="Organizational Value" tagType="organizational-values" initialItems={organizationalValues} />
-      <TagSection title="Estimated Run Frequency" tagType="estimated-run-frequencies" initialItems={estimatedRunFrequencies} />
+      <TagSection
+        title="Organizational Value"
+        tagType="organizational-values"
+        initialItems={organizationalValues}
+      />
+      <TagSection
+        title="Estimated Run Frequency"
+        tagType="estimated-run-frequencies"
+        initialItems={estimatedRunFrequencies}
+      />
       <TagSection title="Fragility Types" tagType="fragilities" initialItems={fragilities} />
       <TagSection title="Fragility Tags" tagType="fragility-tags" initialItems={fragilityTags} />
-      <TagSection title="Maintenance Schedules" tagType="maintenance-schedules" initialItems={maintenanceSchedules} />
-      <TagSection title="Maintenance Log Status" tagType="maintenance-log-statuses" initialItems={maintenanceLogStatuses} />
-      <TagSection title="Financial Impact" tagType="financial-impacts" initialItems={financialImpacts} />
-      <TagSection title="Strategic Importance" tagType="strategic-importances" initialItems={strategicImportances} />
+      <TagSection
+        title="Maintenance Schedules"
+        tagType="maintenance-schedules"
+        initialItems={maintenanceSchedules}
+      />
+      <TagSection
+        title="Maintenance Log Status"
+        tagType="maintenance-log-statuses"
+        initialItems={maintenanceLogStatuses}
+      />
+      <TagSection
+        title="Financial Impact"
+        tagType="financial-impacts"
+        initialItems={financialImpacts}
+      />
+      <TagSection
+        title="Strategic Importance"
+        tagType="strategic-importances"
+        initialItems={strategicImportances}
+      />
       <TagSection title="Tags" tagType="tags" initialItems={tags} hasDescription />
     </div>
   )

--- a/frontend/components/settings/tags-settings-panel.tsx
+++ b/frontend/components/settings/tags-settings-panel.tsx
@@ -1,0 +1,167 @@
+﻿"use client"
+
+import { useState, useTransition } from "react"
+import { createTagAction, deleteTagAction } from "@/app/settings/actions"
+import type { ParameterDto } from "@/lib/settings/types"
+import type { TagType } from "@/lib/settings/api"
+
+interface TagSectionProps {
+  title: string
+  tagType: TagType
+  initialItems: ParameterDto[]
+  hasDescription?: boolean
+}
+
+function TagSection({ title, tagType, initialItems, hasDescription = false }: TagSectionProps) {
+  const [items, setItems] = useState<ParameterDto[]>(initialItems)
+  const [newName, setNewName] = useState("")
+  const [newDesc, setNewDesc] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function handleAdd(e: React.FormEvent) {
+    e.preventDefault()
+    if (!newName.trim()) return
+    startTransition(async () => {
+      setError(null)
+      const res = await createTagAction(tagType, { name: newName.trim(), description: newDesc.trim() || undefined })
+      if (res && "error" in res) {
+        setError(res.error as string)
+      } else if (res && "data" in res) {
+        setItems((prev) => [...prev, res.data as ParameterDto])
+        setNewName("")
+        setNewDesc("")
+      }
+    })
+  }
+
+  function handleDelete(id: number) {
+    if (!confirm("Are you sure you want to remove this?")) return
+    startTransition(async () => {
+      setError(null)
+      const res = await deleteTagAction(tagType, id)
+      if (res && "error" in res) {
+        setError(res.error as string)
+      } else {
+        setItems((prev) => prev.filter((i) => i.id !== id))
+      }
+    })
+  }
+
+  return (
+    <div className="mb-8 last:mb-0 space-y-2">
+      <h4 className="text-[15px] font-bold text-gray-800">{title}</h4>
+      
+      {error && (
+        <div className="bg-red-50 text-red-600 border border-red-200 p-3 rounded-md text-sm">
+          {error}
+        </div>
+      )}
+      
+      <div className="w-full">
+        <table className="w-full text-[13px] text-left" aria-label={title}>
+          <thead>
+            <tr className="border-b border-gray-300">
+              <th className="py-2 font-bold text-gray-800">Name</th>
+              {hasDescription && <th className="py-2 font-bold text-gray-800">Description</th>}
+              <th className="py-2 font-bold text-gray-800 w-24">Used</th>
+              <th className="py-2 font-bold text-gray-800 w-24">Remove</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.length === 0 && (
+              <tr>
+                <td colSpan={hasDescription ? 4 : 3} className="py-4 text-center text-gray-500 border-b border-gray-200">
+                  No items.
+                </td>
+              </tr>
+            )}
+            {items.map((item) => (
+              <tr key={item.id} className="border-b border-gray-200 last:border-b-0 hover:bg-gray-50 transition-colors">
+                <td className="py-2.5 font-bold text-gray-800">{item.name}</td>
+                {hasDescription && <td className="py-2.5 text-gray-700">{item.description ?? ""}</td>}
+                <td className="py-2.5 text-gray-700">{item.used}</td>
+                <td className="py-2.5">
+                  <button
+                    type="button"
+                    className="text-blue-600 hover:text-blue-800 transition-colors inline-flex align-middle"
+                    onClick={() => handleDelete(item.id)}
+                    aria-label={`Delete ${item.name}`}
+                  >
+                    <i className="fas fa-trash"></i>
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      
+      <form onSubmit={handleAdd} className="flex max-w-[300px]">
+        <input
+          className="flex-1 rounded-l border border-gray-300 bg-white px-3 py-1.5 text-[13px] focus:outline-none focus:border-blue-500 placeholder-gray-400"
+          type="text"
+          placeholder={`Add ${title}...`}
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          required
+        />
+        {hasDescription && (
+          <input
+            className="flex-1 border-y border-gray-300 bg-white px-3 py-1.5 text-[13px] focus:outline-none focus:border-blue-500 placeholder-gray-400"
+            type="text"
+            placeholder="Description (optional)"
+            value={newDesc}
+            onChange={(e) => setNewDesc(e.target.value)}
+          />
+        )}
+        <button 
+          className="px-4 py-1.5 bg-[#4a85e6] text-white rounded-r border border-[#4a85e6] text-[13px] font-medium hover:bg-blue-600 transition-colors disabled:opacity-50"
+          type="submit" 
+          disabled={isPending}
+        >
+          Add
+        </button>
+      </form>
+    </div>
+  )
+}
+
+interface Props {
+  organizationalValues: ParameterDto[]
+  estimatedRunFrequencies: ParameterDto[]
+  fragilities: ParameterDto[]
+  fragilityTags: ParameterDto[]
+  maintenanceSchedules: ParameterDto[]
+  maintenanceLogStatuses: ParameterDto[]
+  financialImpacts: ParameterDto[]
+  strategicImportances: ParameterDto[]
+  tags: ParameterDto[]
+}
+
+export function TagsSettingsPanel({
+  organizationalValues,
+  estimatedRunFrequencies,
+  fragilities,
+  fragilityTags,
+  maintenanceSchedules,
+  maintenanceLogStatuses,
+  financialImpacts,
+  strategicImportances,
+  tags,
+}: Props) {
+  return (
+    <div className="space-y-6">
+      <h3 className="text-[28px] font-bold font-serif text-[#2c3e50] mb-8">Meta Fields</h3>
+      <TagSection title="Organizational Value" tagType="organizational-values" initialItems={organizationalValues} />
+      <TagSection title="Estimated Run Frequency" tagType="estimated-run-frequencies" initialItems={estimatedRunFrequencies} />
+      <TagSection title="Fragility Types" tagType="fragilities" initialItems={fragilities} />
+      <TagSection title="Fragility Tags" tagType="fragility-tags" initialItems={fragilityTags} />
+      <TagSection title="Maintenance Schedules" tagType="maintenance-schedules" initialItems={maintenanceSchedules} />
+      <TagSection title="Maintenance Log Status" tagType="maintenance-log-statuses" initialItems={maintenanceLogStatuses} />
+      <TagSection title="Financial Impact" tagType="financial-impacts" initialItems={financialImpacts} />
+      <TagSection title="Strategic Importance" tagType="strategic-importances" initialItems={strategicImportances} />
+      <TagSection title="Tags" tagType="tags" initialItems={tags} hasDescription />
+    </div>
+  )
+}

--- a/frontend/components/settings/user-roles-panel.tsx
+++ b/frontend/components/settings/user-roles-panel.tsx
@@ -1,0 +1,182 @@
+﻿"use client"
+
+import { useState, useTransition } from "react"
+import { Trash2 } from "lucide-react"
+import { addUserRoleAction, removeUserRoleAction } from "@/app/settings/actions"
+import type { RoleDto, UserRoleAssignmentDto } from "@/lib/settings/types"
+
+interface Props {
+  initialAssignments: UserRoleAssignmentDto[]
+  availableRoles: RoleDto[]
+}
+
+export function UserRolesPanel({ initialAssignments, availableRoles }: Props) {
+  const [assignments, setAssignments] = useState<UserRoleAssignmentDto[]>(initialAssignments)
+  const [userSearch, setUserSearch] = useState("")
+  const [selectedUserId, setSelectedUserId] = useState<number | null>(null)
+  const [selectedRoleId, setSelectedRoleId] = useState<number | "">("")
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault()
+    if (!selectedUserId || !selectedRoleId) {
+      setError("User and role are required.")
+      return
+    }
+    setError(null)
+    startTransition(async () => {
+      const res = await addUserRoleAction(selectedUserId, Number(selectedRoleId))
+      if (res && "error" in res) {
+        setError(res.error as string)
+      } else {
+        const role = availableRoles.find((r) => r.id === Number(selectedRoleId))
+        if (!role) return
+        setAssignments((prev) => {
+          const existing = prev.find((a) => a.userId === selectedUserId)
+          if (existing) {
+            return prev.map((a) =>
+              a.userId === selectedUserId
+                ? { ...a, roles: [...a.roles, { id: role.id, name: role.name }] }
+                : a,
+            )
+          }
+          return [...prev, { userId: selectedUserId, name: userSearch, roles: [{ id: role.id, name: role.name }] }]
+        })
+        setUserSearch("")
+        setSelectedUserId(null)
+        setSelectedRoleId("")
+      }
+    })
+  }
+
+  function handleRemove(userId: number, roleId: number) {
+    startTransition(async () => {
+      setError(null)
+      const res = await removeUserRoleAction(userId, roleId)
+      if (res && "error" in res) {
+        setError(res.error as string)
+      } else {
+        setAssignments((prev) =>
+          prev
+            .map((a) =>
+              a.userId === userId ? { ...a, roles: a.roles.filter((r) => r.id !== roleId) } : a,
+            )
+            .filter((a) => a.roles.length > 0),
+        )
+      }
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-2xl font-bold font-serif text-slate-800">User Roles</h2>
+      
+      <div className="space-y-4">
+        <h3 className="text-xl font-semibold text-slate-800">Add Privileged User</h3>
+
+        {error && (
+          <div className="bg-red-50 text-red-600 border border-red-200 p-4 rounded-md">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleAdd} className="space-y-4 max-w-xl">
+          <div className="space-y-2">
+            <label className="block text-sm font-semibold text-slate-700">User</label>
+            <input
+              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="type to search..."
+              value={userSearch}
+              onChange={(e) => setUserSearch(e.target.value)}
+            />
+            {userSearch.length > 1 && (
+              <p className="text-xs text-blue-600">
+                Note: User search requires backend integration. Enter the user ID directly for now.
+              </p>
+            )}
+          </div>
+          
+          <div className="space-y-2">
+            <label className="block text-sm font-semibold text-slate-700">User ID</label>
+            <input
+              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              type="number"
+              placeholder="User ID"
+              value={selectedUserId ?? ""}
+              onChange={(e) => setSelectedUserId(e.target.value ? Number(e.target.value) : null)}
+            />
+          </div>
+          
+          <div className="space-y-2">
+            <label className="block text-sm font-semibold text-slate-700">Role</label>
+            <select
+              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={selectedRoleId}
+              onChange={(e) => setSelectedRoleId(e.target.value ? Number(e.target.value) : "")}
+            >
+              <option value="">Select a role...</option>
+              {availableRoles
+                .filter((r) => r.name !== "Administrator" && r.name !== "User")
+                .map((r) => (
+                  <option key={r.id} value={r.id}>
+                    {r.name}
+                  </option>
+                ))}
+            </select>
+          </div>
+          
+          <button 
+            className="px-4 py-2 bg-blue-500 text-white rounded-md text-sm font-medium hover:bg-blue-600 transition-colors disabled:opacity-50"
+            type="submit" 
+            disabled={isPending}
+          >
+            Save
+          </button>
+        </form>
+      </div>
+
+      <div className="space-y-4">
+        <h3 className="text-xl font-semibold text-slate-800">Privileged Users</h3>
+        <div className="overflow-x-auto border border-slate-200 rounded-md">
+          <table className="w-full text-sm text-left">
+            <thead className="bg-slate-50 border-b border-slate-200 text-slate-700">
+              <tr>
+                <th className="px-4 py-3 font-semibold">User</th>
+                <th className="px-4 py-3 font-semibold">Role</th>
+                <th className="px-4 py-3 font-semibold">Remove Role</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 bg-white">
+              {assignments.length === 0 && (
+                <tr>
+                  <td colSpan={3} className="px-4 py-8 text-center text-slate-500">
+                    No privileged users assigned.
+                  </td>
+                </tr>
+              )}
+              {assignments.map((a) =>
+                a.roles.map((r) => (
+                  <tr key={`${a.userId}-${r.id}`} className="hover:bg-slate-50">
+                    <td className="px-4 py-3 text-slate-900">{a.name}</td>
+                    <td className="px-4 py-3 text-slate-900">{r.name}</td>
+                    <td className="px-4 py-3">
+                      <button
+                        type="button"
+                        className="text-red-500 hover:text-red-700 transition-colors"
+                        onClick={() => handleRemove(a.userId, r.id)}
+                        aria-label={`Remove role ${r.name} from ${a.name}`}
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </td>
+                  </tr>
+                )),
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/settings/user-roles-panel.tsx
+++ b/frontend/components/settings/user-roles-panel.tsx
@@ -1,8 +1,13 @@
 ﻿"use client"
 
-import { useState, useTransition } from "react"
 import { Trash2 } from "lucide-react"
-import { addUserRoleAction, removeUserRoleAction } from "@/app/settings/actions"
+import { useCallback, useState, useTransition } from "react"
+import {
+  addUserRoleAction,
+  removeUserRoleAction,
+  searchSettingsUsersAction,
+} from "@/app/settings/actions"
+import { SettingsTypeahead } from "@/components/settings/settings-typeahead"
 import type { RoleDto, UserRoleAssignmentDto } from "@/lib/settings/types"
 
 interface Props {
@@ -17,6 +22,8 @@ export function UserRolesPanel({ initialAssignments, availableRoles }: Props) {
   const [selectedRoleId, setSelectedRoleId] = useState<number | "">("")
   const [error, setError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
+
+  const fetchUsers = useCallback((query: string) => searchSettingsUsersAction(query), [])
 
   async function handleAdd(e: React.FormEvent) {
     e.preventDefault()
@@ -41,7 +48,10 @@ export function UserRolesPanel({ initialAssignments, availableRoles }: Props) {
                 : a,
             )
           }
-          return [...prev, { userId: selectedUserId, name: userSearch, roles: [{ id: role.id, name: role.name }] }]
+          return [
+            ...prev,
+            { userId: selectedUserId, name: userSearch, roles: [{ id: role.id, name: role.name }] },
+          ]
         })
         setUserSearch("")
         setSelectedUserId(null)
@@ -71,46 +81,34 @@ export function UserRolesPanel({ initialAssignments, availableRoles }: Props) {
   return (
     <div className="space-y-6">
       <h2 className="text-2xl font-bold font-serif text-slate-800">User Roles</h2>
-      
+
       <div className="space-y-4">
         <h3 className="text-xl font-semibold text-slate-800">Add Privileged User</h3>
 
         {error && (
-          <div className="bg-red-50 text-red-600 border border-red-200 p-4 rounded-md">
-            {error}
-          </div>
+          <div className="bg-red-50 text-red-600 border border-red-200 p-4 rounded-md">{error}</div>
         )}
 
         <form onSubmit={handleAdd} className="space-y-4 max-w-xl">
+          <SettingsTypeahead
+            label="User"
+            value={userSearch}
+            selectedId={selectedUserId}
+            onQueryChange={setUserSearch}
+            onSelect={(item) => setSelectedUserId(item.id)}
+            onClear={() => setSelectedUserId(null)}
+            fetchResults={fetchUsers}
+          />
+
           <div className="space-y-2">
-            <label className="block text-sm font-semibold text-slate-700">User</label>
-            <input
-              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="type to search..."
-              value={userSearch}
-              onChange={(e) => setUserSearch(e.target.value)}
-            />
-            {userSearch.length > 1 && (
-              <p className="text-xs text-blue-600">
-                Note: User search requires backend integration. Enter the user ID directly for now.
-              </p>
-            )}
-          </div>
-          
-          <div className="space-y-2">
-            <label className="block text-sm font-semibold text-slate-700">User ID</label>
-            <input
-              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              type="number"
-              placeholder="User ID"
-              value={selectedUserId ?? ""}
-              onChange={(e) => setSelectedUserId(e.target.value ? Number(e.target.value) : null)}
-            />
-          </div>
-          
-          <div className="space-y-2">
-            <label className="block text-sm font-semibold text-slate-700">Role</label>
+            <label
+              htmlFor="user-role-select"
+              className="block text-sm font-semibold text-slate-700"
+            >
+              Role
+            </label>
             <select
+              id="user-role-select"
               className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
               value={selectedRoleId}
               onChange={(e) => setSelectedRoleId(e.target.value ? Number(e.target.value) : "")}
@@ -125,10 +123,10 @@ export function UserRolesPanel({ initialAssignments, availableRoles }: Props) {
                 ))}
             </select>
           </div>
-          
-          <button 
+
+          <button
             className="px-4 py-2 bg-blue-500 text-white rounded-md text-sm font-medium hover:bg-blue-600 transition-colors disabled:opacity-50"
-            type="submit" 
+            type="submit"
             disabled={isPending}
           >
             Save

--- a/frontend/lib/auth/types.ts
+++ b/frontend/lib/auth/types.ts
@@ -2,6 +2,8 @@
 
 export const PERMISSIONS = [
   "Edit Role Permissions",
+  "Edit User Permissions",
+  "Edit Group Permissions",
   "Manage Report-Object Relationships",
   "Approve Terms",
   "Edit Report Documentation",

--- a/frontend/lib/settings/api.ts
+++ b/frontend/lib/settings/api.ts
@@ -1,0 +1,345 @@
+// Settings API client — consumes /api/settings/*
+// All functions run server-side (use `getServerApiBase` + `getToken`).
+// Mutation helpers return a discriminated union so callers can distinguish
+// success / forbidden / validation error / network error without try/catch.
+
+import { getServerApiBase } from "@/lib/api-base"
+import { getToken } from "@/lib/auth"
+import { getUserFriendlyErrorMessage, mapHttpStatusToErrorCode } from "@/lib/errors"
+import type { AppErrorCode } from "@/lib/errors"
+import { apiFetchJson } from "@/lib/http"
+import type {
+  GroupRoleAssignmentDto,
+  ParameterDto,
+  ParameterRequest,
+  PermissionDto,
+  RoleDto,
+  RoleRequest,
+  SearchSettingsDto,
+  SettingValueDto,
+  SiteMessageDto,
+  SiteMessageRequest,
+  UserRoleAssignmentDto,
+} from "./types"
+
+// ---------------------------------------------------------------------------
+// Shared result types
+// ---------------------------------------------------------------------------
+
+export type SettingsOk<T> = { ok: true; data: T }
+export type SettingsErr = { ok: false; message: string; code: AppErrorCode }
+export type SettingsResult<T> = SettingsOk<T> | SettingsErr
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function getAuthHeaders(): Promise<Record<string, string> | null> {
+  const token = await getToken()
+  if (!token) return null
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" }
+}
+
+function noToken(): SettingsErr {
+  return {
+    ok: false,
+    message: getUserFriendlyErrorMessage("auth_required"),
+    code: "auth_required",
+  }
+}
+
+function noBase(): SettingsErr {
+  return {
+    ok: false,
+    message: getUserFriendlyErrorMessage("service_unavailable"),
+    code: "service_unavailable",
+  }
+}
+
+async function parseApiError(res: Response): Promise<string> {
+  const fallback = getUserFriendlyErrorMessage(mapHttpStatusToErrorCode(res.status))
+  try {
+    const text = await res.text()
+    if (!text.trim()) return fallback
+    try {
+      const parsed = JSON.parse(text) as { error?: string; message?: string }
+      return parsed.error ?? parsed.message ?? fallback
+    } catch {
+      return text.length > 300 ? `${text.slice(0, 300)}…` : text
+    }
+  } catch {
+    return fallback
+  }
+}
+
+function errFromStatus(res: Response, message: string): SettingsErr {
+  return { ok: false, message, code: mapHttpStatusToErrorCode(res.status) }
+}
+
+// Generic GET helper
+async function get<T>(path: string): Promise<SettingsResult<T>> {
+  const token = await getToken()
+  if (!token) return noToken()
+  const base = getServerApiBase()
+  if (!base) return noBase()
+
+  const result = await apiFetchJson<T>(`${base}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: "no-store",
+  })
+  if (!result.ok) {
+    return {
+      ok: false,
+      message: getUserFriendlyErrorMessage(result.error.code),
+      code: result.error.code,
+    }
+  }
+  return { ok: true, data: result.data }
+}
+
+// Generic mutation helper (PUT / POST / DELETE)
+async function mutate<T = void>(
+  path: string,
+  method: "GET" | "POST" | "PUT" | "DELETE",
+  body?: unknown,
+): Promise<SettingsResult<T>> {
+  const headers = await getAuthHeaders()
+  if (!headers) return noToken()
+  const base = getServerApiBase()
+  if (!base) return noBase()
+
+  try {
+    const res = await fetch(`${base}${path}`, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    })
+    if (res.ok) {
+      if (res.status === 204) return { ok: true, data: undefined as T }
+      return { ok: true, data: (await res.json()) as T }
+    }
+    return errFromStatus(res, await parseApiError(res))
+  } catch {
+    return noBase()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Permissions (full list from DB)
+// ---------------------------------------------------------------------------
+
+export async function getPermissions(): Promise<SettingsResult<PermissionDto[]>> {
+  return get<PermissionDto[]>("/api/settings/permissions")
+}
+
+// ---------------------------------------------------------------------------
+// Site Messages
+// ---------------------------------------------------------------------------
+
+export async function getSiteMessages(): Promise<SettingsResult<SiteMessageDto[]>> {
+  return get<SiteMessageDto[]>("/api/settings/site-messages")
+}
+
+export async function addSiteMessage(
+  body: SiteMessageRequest,
+): Promise<SettingsResult<SiteMessageDto>> {
+  return mutate<SiteMessageDto>("/api/settings/site-messages", "POST", body)
+}
+
+export async function deleteSiteMessage(id: number): Promise<SettingsResult<void>> {
+  return mutate<void>(`/api/settings/site-messages/${id}`, "DELETE")
+}
+
+// ---------------------------------------------------------------------------
+// ETL
+// ---------------------------------------------------------------------------
+
+export async function getEtl(): Promise<SettingsResult<SettingValueDto>> {
+  return get<SettingValueDto>("/api/settings/etl")
+}
+
+export async function getDefaultEtl(): Promise<SettingsResult<string>> {
+  const token = await getToken()
+  if (!token) return noToken()
+  const base = getServerApiBase()
+  if (!base) return noBase()
+  try {
+    const res = await fetch(`${base}/api/settings/etl/default`, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    })
+    if (res.ok) return { ok: true, data: await res.text() }
+    return errFromStatus(res, await parseApiError(res))
+  } catch {
+    return noBase()
+  }
+}
+
+export async function updateEtl(value: string | null): Promise<SettingsResult<void>> {
+  return mutate<void>("/api/settings/etl", "PUT", { value })
+}
+
+// ---------------------------------------------------------------------------
+// Theme
+// ---------------------------------------------------------------------------
+
+export async function getTheme(): Promise<SettingsResult<SettingValueDto>> {
+  return get<SettingValueDto>("/api/settings/theme")
+}
+
+export async function updateTheme(value: string | null): Promise<SettingsResult<void>> {
+  return mutate<void>("/api/settings/theme", "PUT", { value })
+}
+
+// ---------------------------------------------------------------------------
+// Search
+// ---------------------------------------------------------------------------
+
+export async function getSearch(): Promise<SettingsResult<SearchSettingsDto>> {
+  return get<SearchSettingsDto>("/api/settings/search")
+}
+
+export async function updateSearchVisibility(
+  type: string,
+  visible: boolean,
+  reportTypeId?: number,
+): Promise<SettingsResult<void>> {
+  const params =
+    type === "reports" && reportTypeId !== undefined
+      ? `?reportTypeId=${reportTypeId}`
+      : ""
+  return mutate<void>(`/api/settings/search/${type}/visibility${params}`, "PUT", { visible })
+}
+
+export async function updateSearchReportTypeText(
+  id: number,
+  text: string | null,
+): Promise<SettingsResult<void>> {
+  return mutate<void>(`/api/settings/search/report-types/${id}/text`, "PUT", { text })
+}
+
+// ---------------------------------------------------------------------------
+// Tags / metadata parameters
+// ---------------------------------------------------------------------------
+
+export const TAG_TYPES = [
+  "organizational-values",
+  "estimated-run-frequencies",
+  "maintenance-schedules",
+  "fragilities",
+  "fragility-tags",
+  "tags",
+  "maintenance-log-statuses",
+  "financial-impacts",
+  "strategic-importances",
+] as const
+
+export type TagType = (typeof TAG_TYPES)[number]
+
+export async function getTags(type: TagType): Promise<SettingsResult<ParameterDto[]>> {
+  return get<ParameterDto[]>(`/api/settings/tags/${type}`)
+}
+
+export async function createTag(
+  type: TagType,
+  body: ParameterRequest,
+): Promise<SettingsResult<ParameterDto>> {
+  return mutate<ParameterDto>(`/api/settings/tags/${type}`, "POST", body)
+}
+
+export async function deleteTag(type: TagType, id: number): Promise<SettingsResult<void>> {
+  return mutate<void>(`/api/settings/tags/${type}/${id}`, "DELETE")
+}
+
+// ---------------------------------------------------------------------------
+// Roles
+// ---------------------------------------------------------------------------
+
+export async function getRoles(): Promise<SettingsResult<RoleDto[]>> {
+  return get<RoleDto[]>("/api/settings/roles")
+}
+
+export async function createRole(body: RoleRequest): Promise<SettingsResult<RoleDto>> {
+  return mutate<RoleDto>("/api/settings/roles", "POST", body)
+}
+
+export async function deleteRole(id: number): Promise<SettingsResult<void>> {
+  return mutate<void>(`/api/settings/roles/${id}`, "DELETE")
+}
+
+export async function updateRolePermission(
+  roleId: number,
+  permissionId: number,
+  enabled: boolean,
+): Promise<SettingsResult<void>> {
+  return mutate<void>(`/api/settings/roles/${roleId}/permissions/${permissionId}`, "PUT", {
+    enabled,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// User Roles
+// ---------------------------------------------------------------------------
+
+export async function getUserRoles(): Promise<SettingsResult<UserRoleAssignmentDto[]>> {
+  return get<UserRoleAssignmentDto[]>("/api/settings/user-roles")
+}
+
+export async function addUserRole(userId: number, roleId: number): Promise<SettingsResult<void>> {
+  return mutate<void>(`/api/settings/user-roles/${userId}`, "POST", { roleId })
+}
+
+export async function removeUserRole(
+  userId: number,
+  roleId: number,
+): Promise<SettingsResult<void>> {
+  return mutate<void>(`/api/settings/user-roles/${userId}/${roleId}`, "DELETE")
+}
+
+// ---------------------------------------------------------------------------
+// Group Roles
+// ---------------------------------------------------------------------------
+
+export async function getGroupRoles(): Promise<SettingsResult<GroupRoleAssignmentDto[]>> {
+  return get<GroupRoleAssignmentDto[]>("/api/settings/group-roles")
+}
+
+export async function addGroupRole(
+  groupId: number,
+  roleId: number,
+): Promise<SettingsResult<void>> {
+  return mutate<void>(`/api/settings/group-roles/${groupId}`, "POST", { roleId })
+}
+
+export async function removeGroupRole(
+  groupId: number,
+  roleId: number,
+): Promise<SettingsResult<void>> {
+  return mutate<void>(`/api/settings/group-roles/${groupId}/${roleId}`, "DELETE")
+}
+
+// ---------------------------------------------------------------------------
+// Available permissions list (re-used by the Roles UI)
+// ---------------------------------------------------------------------------
+
+export const ALL_PERMISSIONS: PermissionDto[] = [
+  { id: 1, name: "Manage Global Site Settings" },
+  { id: 2, name: "Create Parameters" },
+  { id: 3, name: "Delete Parameters" },
+  { id: 4, name: "Edit Role Permissions" },
+  { id: 5, name: "Edit User Permissions" },
+  { id: 6, name: "Edit Group Permissions" },
+  { id: 7, name: "Approve Terms" },
+  { id: 8, name: "Edit Report Documentation" },
+  { id: 9, name: "Create New Terms" },
+  { id: 10, name: "Edit Terms" },
+  { id: 11, name: "Create Collection" },
+  { id: 12, name: "Edit Collection" },
+  { id: 13, name: "Delete Collection" },
+  { id: 14, name: "Create Initiative" },
+  { id: 15, name: "View Other User" },
+  { id: 16, name: "Show Advanced Search" },
+  { id: 17, name: "Show Report-Object Relationships" },
+  { id: 18, name: "Manage Report-Object Relationships" },
+  { id: 19, name: "Edit Report-Object Relationships" },
+]

--- a/frontend/lib/settings/api.ts
+++ b/frontend/lib/settings/api.ts
@@ -5,8 +5,8 @@
 
 import { getServerApiBase } from "@/lib/api-base"
 import { getToken } from "@/lib/auth"
-import { getUserFriendlyErrorMessage, mapHttpStatusToErrorCode } from "@/lib/errors"
 import type { AppErrorCode } from "@/lib/errors"
+import { getUserFriendlyErrorMessage, mapHttpStatusToErrorCode } from "@/lib/errors"
 import { apiFetchJson } from "@/lib/http"
 import type {
   GroupRoleAssignmentDto,
@@ -205,9 +205,7 @@ export async function updateSearchVisibility(
   reportTypeId?: number,
 ): Promise<SettingsResult<void>> {
   const params =
-    type === "reports" && reportTypeId !== undefined
-      ? `?reportTypeId=${reportTypeId}`
-      : ""
+    type === "reports" && reportTypeId !== undefined ? `?reportTypeId=${reportTypeId}` : ""
   return mutate<void>(`/api/settings/search/${type}/visibility${params}`, "PUT", { visible })
 }
 
@@ -304,10 +302,7 @@ export async function getGroupRoles(): Promise<SettingsResult<GroupRoleAssignmen
   return get<GroupRoleAssignmentDto[]>("/api/settings/group-roles")
 }
 
-export async function addGroupRole(
-  groupId: number,
-  roleId: number,
-): Promise<SettingsResult<void>> {
+export async function addGroupRole(groupId: number, roleId: number): Promise<SettingsResult<void>> {
   return mutate<void>(`/api/settings/group-roles/${groupId}`, "POST", { roleId })
 }
 
@@ -317,29 +312,3 @@ export async function removeGroupRole(
 ): Promise<SettingsResult<void>> {
   return mutate<void>(`/api/settings/group-roles/${groupId}/${roleId}`, "DELETE")
 }
-
-// ---------------------------------------------------------------------------
-// Available permissions list (re-used by the Roles UI)
-// ---------------------------------------------------------------------------
-
-export const ALL_PERMISSIONS: PermissionDto[] = [
-  { id: 1, name: "Manage Global Site Settings" },
-  { id: 2, name: "Create Parameters" },
-  { id: 3, name: "Delete Parameters" },
-  { id: 4, name: "Edit Role Permissions" },
-  { id: 5, name: "Edit User Permissions" },
-  { id: 6, name: "Edit Group Permissions" },
-  { id: 7, name: "Approve Terms" },
-  { id: 8, name: "Edit Report Documentation" },
-  { id: 9, name: "Create New Terms" },
-  { id: 10, name: "Edit Terms" },
-  { id: 11, name: "Create Collection" },
-  { id: 12, name: "Edit Collection" },
-  { id: 13, name: "Delete Collection" },
-  { id: 14, name: "Create Initiative" },
-  { id: 15, name: "View Other User" },
-  { id: 16, name: "Show Advanced Search" },
-  { id: 17, name: "Show Report-Object Relationships" },
-  { id: 18, name: "Manage Report-Object Relationships" },
-  { id: 19, name: "Edit Report-Object Relationships" },
-]

--- a/frontend/lib/settings/types.ts
+++ b/frontend/lib/settings/types.ts
@@ -1,0 +1,67 @@
+// Settings API type definitions — mirrors web/Contracts/Api/Settings/SettingsDtos.cs
+
+export interface SettingValueDto {
+  value: string | null
+}
+
+export interface SiteMessageDto {
+  id: number
+  value: string
+  description: string | null
+}
+
+export interface SiteMessageRequest {
+  value: string
+  description?: string | null
+}
+
+export interface SearchReportTypeDto {
+  id: number
+  name: string
+  shortName: string | null
+  visible: boolean
+}
+
+export interface SearchSettingsDto {
+  visibility: Record<string, string>
+  reportTypes: SearchReportTypeDto[]
+}
+
+export interface ParameterDto {
+  id: number
+  name: string
+  description: string | null
+  used: number
+}
+
+export interface ParameterRequest {
+  name: string
+  description?: string | null
+}
+
+export interface PermissionDto {
+  id: number
+  name: string
+}
+
+export interface RoleDto {
+  id: number
+  name: string
+  permissions: PermissionDto[]
+}
+
+export interface RoleRequest {
+  name: string
+}
+
+export interface UserRoleAssignmentDto {
+  userId: number
+  name: string
+  roles: PermissionDto[]
+}
+
+export interface GroupRoleAssignmentDto {
+  groupId: number
+  name: string
+  roles: PermissionDto[]
+}

--- a/web.Tests/FunctionTests/Controllers/SettingsApiController.Tests.cs
+++ b/web.Tests/FunctionTests/Controllers/SettingsApiController.Tests.cs
@@ -24,6 +24,7 @@ public class SettingsApiControllerTests
 
         Assert.Contains(methods, method => method.GetCustomAttribute<HttpGetAttribute>()?.Template == "site-messages");
         Assert.Contains(methods, method => method.GetCustomAttribute<HttpGetAttribute>()?.Template == "search");
+        Assert.Contains(methods, method => method.GetCustomAttribute<HttpGetAttribute>()?.Template == "permissions");
         Assert.Contains(methods, method => method.GetCustomAttribute<HttpGetAttribute>()?.Template == "roles");
         Assert.Contains(methods, method => method.GetCustomAttribute<HttpGetAttribute>()?.Template == "tags/{type}");
     }
@@ -46,6 +47,25 @@ public class SettingsApiControllerTests
             new SiteMessageRequestDto { Value = "2", Description = "Updated" })).Result);
         Assert.Equal("2", Assert.IsType<SiteMessageDto>(created.Value).Value);
         Assert.Equal(2, await context.GlobalSiteSettings.CountAsync(x => x.Name == "msg"));
+    }
+
+    [Fact]
+    public async Task Permissions_ReturnsOrderedListFromDatabase()
+    {
+        await using var context = new Atlas_WebContext(new DbContextOptionsBuilder<Atlas_WebContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options);
+        context.RolePermissions.AddRange(
+            new RolePermission { RolePermissionsId = 2, Name = "Create Parameters" },
+            new RolePermission { RolePermissionsId = 1, Name = "Approve Terms" });
+        await context.SaveChangesAsync();
+        var controller = BuildController(context);
+
+        var result = Assert.IsType<OkObjectResult>((await controller.GetPermissions()).Result);
+        var permissions = Assert.IsAssignableFrom<IReadOnlyList<PermissionDto>>(result.Value);
+
+        Assert.Equal(2, permissions.Count);
+        Assert.Equal("Approve Terms", permissions[0].Name);
+        Assert.Equal("Create Parameters", permissions[1].Name);
     }
 
     [Fact]

--- a/web/Controllers/Api/SettingsApiController.cs
+++ b/web/Controllers/Api/SettingsApiController.cs
@@ -129,6 +129,14 @@ public sealed class SettingsApiController : ControllerBase
         return NoContent();
     }
 
+    [HttpGet("permissions")]
+    public async Task<ActionResult<IReadOnlyList<PermissionDto>>> GetPermissions(CancellationToken cancellationToken = default)
+    {
+        return Ok(await _context.RolePermissions.OrderBy(x => x.Name)
+            .Select(x => new PermissionDto { Id = x.RolePermissionsId, Name = x.Name })
+            .ToListAsync(cancellationToken));
+    }
+
     [HttpGet("roles")]
     public async Task<ActionResult<IReadOnlyList<RoleDto>>> GetRoles(CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
- Replace all Razor handler dependencies with /api/settings/* API calls
- Add frontend/lib/settings/api.ts: typed client for all settings endpoints
- Add frontend/lib/settings/types.ts: shared DTO types
- Add frontend/app/settings/: single hash-routed settings page (layout + page + actions)
- Add frontend/components/settings/: all panel components
  - roles-panel.tsx: permissions matrix (rows=permissions, cols=roles)
  - user-roles-panel.tsx: user-role assignment table
  - group-roles-panel.tsx: group-role assignment table
  - tags-settings-panel.tsx: 9 metadata parameter lists
  - site-messages-panel.tsx: global site messages CRUD
  - search-settings-panel.tsx: visibility toggles + name overrides
  - etl-theme-panel.tsx: ETL SQL + global CSS theme editors
  - settings-tab-controller.tsx: hash-based tab routing (matches Razor #hash nav)
- Frontend tests cover reads, writes, validation, and forbidden responses
- Typecheck and lint pass with zero errors

Closes #802

<!-- Thanks for contributing! 🤠 -->